### PR TITLE
Add Project References to ProjectContext

### DIFF
--- a/src/Microsoft.Extensions.ProjectModel.Abstractions.Sources/IProjectContext.cs
+++ b/src/Microsoft.Extensions.ProjectModel.Abstractions.Sources/IProjectContext.cs
@@ -29,5 +29,6 @@ namespace Microsoft.Extensions.ProjectModel
         string FindProperty(string propertyName);
         IEnumerable<DependencyDescription> PackageDependencies { get;}
         IEnumerable<ResolvedReference> CompilationAssemblies { get; }
+        IEnumerable<string> ProjectReferences { get; }
     }
 }

--- a/src/Microsoft.Extensions.ProjectModel.DotNet.Sources/DotNetProjectContext.cs
+++ b/src/Microsoft.Extensions.ProjectModel.DotNet.Sources/DotNetProjectContext.cs
@@ -22,6 +22,7 @@ namespace Microsoft.Extensions.ProjectModel
 
         private IEnumerable<DependencyDescription> _packageDependencies;
         private IEnumerable<ResolvedReference> _compilationAssemblies;
+        private IEnumerable<string> _projectReferences;
 
         public DotNetProjectContext(ProjectContext projectContext, string configuration, string outputPath)
         {
@@ -115,6 +116,19 @@ namespace Microsoft.Extensions.ProjectModel
                 }
 
                 return _compilationAssemblies;
+            }
+        }
+
+        public IEnumerable<string> ProjectReferences
+        {
+            get
+            {
+                if (_projectReferences == null)
+                {
+                    _projectReferences = _dependencyProvider.Value.GetProjectReferences();
+                }
+
+                return _projectReferences;
             }
         }
 

--- a/src/Microsoft.Extensions.ProjectModel.MsBuild.Sources/MsBuildProjectContext.cs
+++ b/src/Microsoft.Extensions.ProjectModel.MsBuild.Sources/MsBuildProjectContext.cs
@@ -20,6 +20,7 @@ namespace Microsoft.Extensions.ProjectModel
         private readonly MsBuildProjectDependencyProvider _dependencyProvider;
         private IEnumerable<DependencyDescription> _packageDependencies;
         private IEnumerable<ResolvedReference> _compilationAssemblies;
+        private IEnumerable<string> _projectReferences;
 
         protected ProjectInstance Project { get; }
         protected string Name { get; }
@@ -114,5 +115,17 @@ namespace Microsoft.Extensions.ProjectModel
             }
         }
 
+        public IEnumerable<string> ProjectReferences
+        {
+            get
+            {
+                if (_projectReferences == null)
+                {
+                    _projectReferences = _dependencyProvider.GetProjectReferences();
+                }
+
+                return _projectReferences;
+            }
+        }
     }
 }

--- a/src/Microsoft.Extensions.ProjectModel.MsBuild.Sources/MsBuildProjectDependencyProvider.cs
+++ b/src/Microsoft.Extensions.ProjectModel.MsBuild.Sources/MsBuildProjectDependencyProvider.cs
@@ -25,6 +25,18 @@ namespace Microsoft.Extensions.ProjectModel
             _projectInstance = projectInstance;
         }
 
+        public IEnumerable<string> GetProjectReferences()
+        {
+            var projectPaths = _projectInstance
+                .GetItems("ProjectReference")
+                .Select(reference => reference.EvaluatedInclude);
+
+            return projectPaths
+                .Select(path => Path.IsPathRooted(path)
+                    ? path
+                    : Path.Combine(_projectInstance.Directory, path));
+        }
+
         public IEnumerable<DependencyDescription> GetPackageDependencies()
         {
             var packageItems = _projectInstance.GetItems(PackageDependencyItemType);

--- a/test/Microsoft.Extensions.ProjectModel.Tests/MsBuild/MsBuildProjectDependencyProviderTests.cs
+++ b/test/Microsoft.Extensions.ProjectModel.Tests/MsBuild/MsBuildProjectDependencyProviderTests.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Extensions.ProjectModel.MsBuild
     </PackageReference>
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include=""..\Library1\library.csproj"" />
+    <ProjectReference Include=""..\Library1\Library1.csproj"" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include = ""xyz.dll"" />
@@ -109,14 +109,14 @@ namespace Microsoft.Extensions.ProjectModel.MsBuild
                 fileProvider.Add("NuGet.config", NugetConfigTxt);
 
                 // Add Root Project
-                fileProvider.Add($"Root{Path.DirectorySeparatorChar}test.csproj", RootProjectTxt);
-                fileProvider.Add($"Root{Path.DirectorySeparatorChar}One.cs", "public class Abc {}");
-                fileProvider.Add($"Root{Path.DirectorySeparatorChar}Two.cs", "public class Abc2 {}");
-                fileProvider.Add($"Root{Path.DirectorySeparatorChar}Excluded.cs", "public class Abc {}");
+                fileProvider.Add($"Root/test.csproj", RootProjectTxt);
+                fileProvider.Add($"Root/One.cs", "public class Abc {}");
+                fileProvider.Add($"Root/Two.cs", "public class Abc2 {}");
+                fileProvider.Add($"Root/Excluded.cs", "public class Abc {}");
 
                 // Add Class Library project
-                fileProvider.Add($"Library1{Path.DirectorySeparatorChar}library.csproj", LibraryProjectTxt);
-                fileProvider.Add($"Library1{Path.DirectorySeparatorChar}Three.cs", "public class Abc3 {}");
+                fileProvider.Add($"Library1/Library1.csproj", LibraryProjectTxt);
+                fileProvider.Add($"Library1/Three.cs", "public class Abc3 {}");
 
                 var testContext = _fixture.GetMsBuildContext();
 
@@ -152,9 +152,8 @@ namespace Microsoft.Extensions.ProjectModel.MsBuild
                     .FirstOrDefault();
 
                 Assert.NotNull(lib1Dll);
-                var expectedPath = Path.Combine(fileProvider.Root, "Root", "bin", "Debug", "netcoreapp1.0", "lib1.dll");
-                Assert.Equal(expectedPath, lib1Dll.ResolvedPath, ignoreCase: true);
-                
+                Assert.True(File.Exists(lib1Dll.ResolvedPath));
+
                 // This reference doesn't resolve so should not be available here.
                 Assert.False(compilationAssemblies.Any(assembly => assembly.Name.Equals("xyz", StringComparison.OrdinalIgnoreCase)));
 
@@ -165,6 +164,8 @@ namespace Microsoft.Extensions.ProjectModel.MsBuild
                 Assert.NotNull(mvcPackage);
 
                 Assert.True(mvcPackage.Dependencies.Any(dependency => dependency.Name.Equals("Microsoft.Extensions.DependencyInjection", StringComparison.OrdinalIgnoreCase)));
+
+                Assert.True(context.ProjectReferences.First().Equals(Path.Combine(fileProvider.Root, "Library1", "Library1.csproj")));
             }
         }
     }


### PR DESCRIPTION
cc  @natemcmaster @NTaylorMullen 

The project references are needed while building a Roslyn workspace. 