### PR TITLE
Lift tools versions to 1.1.0

### DIFF
--- a/src/Microsoft.DotNet.Watcher.Tools/README.md
+++ b/src/Microsoft.DotNet.Watcher.Tools/README.md
@@ -6,13 +6,11 @@ dotnet-watch
 
 Add `Microsoft.DotNet.Watcher.Tools` to the `tools` section of your `project.json` file.
 
-Use the version "1.0.0-preview2-final" if you are using .NET Core 1.0.0 and use "1.0.0-preview3-final" if you are using .NET Core 1.1.0.
-
-```
+```js
 {
 ...
   "tools": {
-    "Microsoft.DotNet.Watcher.Tools": "1.0.0-preview2-final" //"1.0.0-preview3-final" for .NET Core 1.1.0
+    "Microsoft.DotNet.Watcher.Tools": "1.0.0-preview4-final" // "1.1.0-preview4-final" for .NET Core 1.1.0
   }
 ...
 }

--- a/src/Microsoft.DotNet.Watcher.Tools/project.json
+++ b/src/Microsoft.DotNet.Watcher.Tools/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.0-*",
+  "version": "1.1.0-*",
   "description": "Command line tool to watch for source file changes during development and restart the dotnet command.",
   "packOptions": {
     "tags": [
@@ -24,7 +24,7 @@
     },
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.1.0-*"
+      "version": "1.1.0"
     }
   },
   "frameworks": {

--- a/src/Microsoft.Extensions.Caching.SqlConfig.Tools/project.json
+++ b/src/Microsoft.Extensions.Caching.SqlConfig.Tools/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.0-*",
+  "version": "1.1.0-*",
   "buildOptions": {
     "outputName": "dotnet-sql-cache",
     "emitEntryPoint": true,
@@ -23,7 +23,7 @@
     "Microsoft.Extensions.Logging": "1.1.0-*",
     "Microsoft.Extensions.Logging.Console": "1.1.0-*",
     "Microsoft.NETCore.App": {
-      "version": "1.1.0-*",
+      "version": "1.1.0",
       "type": "platform"
     },
     "System.Data.SqlClient": "4.3.0-*"

--- a/src/Microsoft.Extensions.SecretManager.Tools/README.md
+++ b/src/Microsoft.Extensions.SecretManager.Tools/README.md
@@ -11,7 +11,7 @@ Add `Microsoft.Extensions.SecretManager.Tools` to the `tools` section of your `p
 {
     ..
     "tools": {
-        "Microsoft.Extensions.SecretManager.Tools": "1.0.0-*"
+        "Microsoft.Extensions.SecretManager.Tools": "1.0.0-preview4-final"  // "1.1.0-preview4-final" for .NET Core 1.1.0
     }
     ...
 }

--- a/src/Microsoft.Extensions.SecretManager.Tools/project.json
+++ b/src/Microsoft.Extensions.SecretManager.Tools/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.0-*",
+  "version": "1.1.0-*",
   "buildOptions": {
     "outputName": "dotnet-user-secrets",
     "emitEntryPoint": true,
@@ -23,7 +23,7 @@
     "Microsoft.Extensions.Configuration.UserSecrets": "1.1.0-*",
     "Microsoft.Extensions.Logging": "1.1.0-*",
     "Microsoft.NETCore.App": {
-      "version": "1.1.0-*",
+      "version": "1.1.0",
       "type": "platform"
     },
     "Newtonsoft.Json": "9.0.1",

--- a/test/Microsoft.DotNet.Watcher.Tools.FunctionalTests/project.json
+++ b/test/Microsoft.DotNet.Watcher.Tools.FunctionalTests/project.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "dotnet-test-xunit": "2.2.0-*",
     "Microsoft.AspNetCore.Testing": "1.1.0-*",
-    "Microsoft.DotNet.Watcher.Tools": "1.0.0-*",
+    "Microsoft.DotNet.Watcher.Tools": "1.1.0-*",
     "Microsoft.Extensions.Process.Sources": {
       "type": "build",
       "version": "1.1.0-*"
@@ -20,11 +20,11 @@
     "xunit": "2.2.0-*"
   },
   "frameworks": {
-    "netcoreapp1.0": {
+    "netcoreapp1.1": {
       "dependencies": {
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.1.0-*"
+          "version": "1.1.0"
         }
       }
     }

--- a/test/Microsoft.DotNet.Watcher.Tools.Tests/project.json
+++ b/test/Microsoft.DotNet.Watcher.Tools.Tests/project.json
@@ -5,14 +5,14 @@
   },
   "dependencies": {
     "dotnet-test-xunit": "2.2.0-*",
-    "Microsoft.DotNet.Watcher.Tools": "1.0.0-*",
+    "Microsoft.DotNet.Watcher.Tools": "1.1.0-*",
     "xunit": "2.2.0-*"
   },
   "frameworks": {
-    "netcoreapp1.0": {
+    "netcoreapp1.1": {
       "dependencies": {
         "Microsoft.NETCore.App": {
-          "version": "1.1.0-*",
+          "version": "1.1.0",
           "type": "platform"
         }
       }

--- a/test/Microsoft.Extensions.SecretManager.Tools.Tests/project.json
+++ b/test/Microsoft.Extensions.SecretManager.Tools.Tests/project.json
@@ -5,15 +5,15 @@
   },
   "dependencies": {
     "dotnet-test-xunit": "2.2.0-*",
-    "Microsoft.Extensions.SecretManager.Tools": "1.0.0-*",
+    "Microsoft.Extensions.SecretManager.Tools": "1.1.0-*",
     "xunit": "2.2.0-*"
   },
   "testRunner": "xunit",
   "frameworks": {
-    "netcoreapp1.0": {
+    "netcoreapp1.1": {
       "dependencies": {
         "Microsoft.NETCore.App": {
-          "version": "1.1.0-*",
+          "version": "1.1.0",
           "type": "platform"
         }
       }

--- a/tools/NuGetPackager/project.json
+++ b/tools/NuGetPackager/project.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.1.0-*"
+      "version": "1.1.0"
     },
     "Microsoft.DotNet.ProjectModel": "1.0.0-*",
     "Microsoft.DotNet.Cli.Utils": "1.0.0-*",


### PR DESCRIPTION
Tools that require .NET Core 1.1 should version as 1.1.

cc @muratg @Eilon @shanselman 
 