### PR TITLE
Downgrade Microsoft.NetCore.App to 1.0

### DIFF
--- a/src/Microsoft.DotNet.Watcher.Tools/project.json
+++ b/src/Microsoft.DotNet.Watcher.Tools/project.json
@@ -24,7 +24,7 @@
     },
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.1.0-*"
+      "version": "1.0.0"
     }
   },
   "frameworks": {

--- a/src/Microsoft.Extensions.Caching.SqlConfig.Tools/project.json
+++ b/src/Microsoft.Extensions.Caching.SqlConfig.Tools/project.json
@@ -23,7 +23,7 @@
     "Microsoft.Extensions.Logging": "1.1.0-*",
     "Microsoft.Extensions.Logging.Console": "1.1.0-*",
     "Microsoft.NETCore.App": {
-      "version": "1.1.0-*",
+      "version": "1.0.0",
       "type": "platform"
     },
     "System.Data.SqlClient": "4.3.0-*"

--- a/src/Microsoft.Extensions.SecretManager.Tools/project.json
+++ b/src/Microsoft.Extensions.SecretManager.Tools/project.json
@@ -23,7 +23,7 @@
     "Microsoft.Extensions.Configuration.UserSecrets": "1.1.0-*",
     "Microsoft.Extensions.Logging": "1.1.0-*",
     "Microsoft.NETCore.App": {
-      "version": "1.1.0-*",
+      "version": "1.0.0",
       "type": "platform"
     },
     "Newtonsoft.Json": "9.0.1",

--- a/test/Microsoft.DotNet.Watcher.Tools.FunctionalTests/project.json
+++ b/test/Microsoft.DotNet.Watcher.Tools.FunctionalTests/project.json
@@ -24,7 +24,7 @@
       "dependencies": {
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.1.0-*"
+          "version": "1.0.0"
         }
       }
     }

--- a/test/Microsoft.DotNet.Watcher.Tools.Tests/project.json
+++ b/test/Microsoft.DotNet.Watcher.Tools.Tests/project.json
@@ -12,7 +12,7 @@
     "netcoreapp1.0": {
       "dependencies": {
         "Microsoft.NETCore.App": {
-          "version": "1.1.0-*",
+          "version": "1.0.0",
           "type": "platform"
         }
       }

--- a/test/Microsoft.Extensions.SecretManager.Tools.Tests/project.json
+++ b/test/Microsoft.Extensions.SecretManager.Tools.Tests/project.json
@@ -13,7 +13,7 @@
     "netcoreapp1.0": {
       "dependencies": {
         "Microsoft.NETCore.App": {
-          "version": "1.1.0-*",
+          "version": "1.0.0",
           "type": "platform"
         }
       }


### PR DESCRIPTION
Based on user feedback, the 1.0.0-preview3-final version had a confusing dependency on .NET Core 1.1-preview1. This downgrades back to .NET Core 1.0. For those with 1.1, there will be a parallel version available. https://github.com/aspnet/DotNetTools/pull/215

cref https://github.com/aspnet/DotNetTools/issues/207 https://github.com/aspnet/DotNetTools/issues/208

