### PR TITLE
dotnet-watch: remove dependency on Microsoft.DotNet.Cli.Utils

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ project.lock.json
 testWorkDir/
 *.nuget.props
 *.nuget.targets
+.idea/

--- a/src/Microsoft.DotNet.Watcher.Tools/CommandLineOptions.cs
+++ b/src/Microsoft.DotNet.Watcher.Tools/CommandLineOptions.cs
@@ -1,9 +1,9 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.IO;
-using Microsoft.DotNet.Cli.Utils;
 using Microsoft.DotNet.Watcher.Tools;
 using Microsoft.DotNet.Watcher.Internal;
 using Microsoft.Extensions.CommandLineUtils;

--- a/src/Microsoft.DotNet.Watcher.Tools/DotNetWatcher.cs
+++ b/src/Microsoft.DotNet.Watcher.Tools/DotNetWatcher.cs
@@ -5,6 +5,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.DotNet.Watcher.Internal;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Tools.Internal;
 
 namespace Microsoft.DotNet.Watcher
 {
@@ -44,6 +45,10 @@ namespace Microsoft.DotNet.Watcher
                 {
                     var fileSetTask = fileSetWatcher.GetChangedFileAsync(combinedCancellationSource.Token);
                     var processTask = _processRunner.RunAsync(processSpec, combinedCancellationSource.Token);
+
+                    _logger.LogInformation("Running {execName} with the following arguments: {args}",
+                        processSpec.ShortDisplayName(),
+                        ArgumentEscaper.EscapeAndConcatenate(processSpec.Arguments));
 
                     var finishedTask = await Task.WhenAny(processTask, fileSetTask, cancelledTaskSource.Task);
 

--- a/src/Microsoft.DotNet.Watcher.Tools/Internal/MsBuildProjectFinder.cs
+++ b/src/Microsoft.DotNet.Watcher.Tools/Internal/MsBuildProjectFinder.cs
@@ -4,7 +4,6 @@
 using System;
 using System.IO;
 using System.Linq;
-using Microsoft.DotNet.Cli.Utils;
 using Microsoft.DotNet.Watcher.Tools;
 
 namespace Microsoft.DotNet.Watcher.Internal
@@ -35,12 +34,12 @@ namespace Microsoft.DotNet.Watcher.Internal
 
                 if (projects.Count > 1)
                 {
-                    throw new GracefulException(Resources.FormatError_MultipleProjectsFound(projectPath));
+                    throw new FileNotFoundException(Resources.FormatError_MultipleProjectsFound(projectPath));
                 }
 
                 if (projects.Count == 0)
                 {
-                    throw new GracefulException(Resources.FormatError_NoProjectsFound(projectPath));
+                    throw new FileNotFoundException(Resources.FormatError_NoProjectsFound(projectPath));
                 }
 
                 return projects[0];
@@ -48,7 +47,7 @@ namespace Microsoft.DotNet.Watcher.Internal
 
             if (!File.Exists(projectPath))
             {
-                throw new GracefulException(Resources.FormatError_ProjectPath_NotFound(projectPath));
+                throw new FileNotFoundException(Resources.FormatError_ProjectPath_NotFound(projectPath));
             }
 
             return projectPath;

--- a/src/Microsoft.DotNet.Watcher.Tools/Internal/OutputCapture.cs
+++ b/src/Microsoft.DotNet.Watcher.Tools/Internal/OutputCapture.cs
@@ -1,0 +1,14 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+
+namespace Microsoft.DotNet.Watcher.Internal
+{
+    public class OutputCapture
+    {
+        private readonly List<string> _lines = new List<string>();
+        public IEnumerable<string> Lines => _lines;
+        public void AddLine(string line) => _lines.Add(line);
+    }
+}

--- a/src/Microsoft.DotNet.Watcher.Tools/Internal/OutputSink.cs
+++ b/src/Microsoft.DotNet.Watcher.Tools/Internal/OutputSink.cs
@@ -1,27 +1,14 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-
 namespace Microsoft.DotNet.Watcher.Internal
 {
-    internal class OutputSink
+    public class OutputSink
     {
         public OutputCapture Current { get; private set; }
         public OutputCapture StartCapture()
         {
             return (Current = new OutputCapture());
-        }
-
-        public class OutputCapture
-        {
-            private readonly List<string> _lines = new List<string>();
-            public IEnumerable<string> Lines => _lines;
-            public void WriteOutputLine(string line) => _lines.Add(line);
-            public void WriteErrorLine(string line) => _lines.Add(line);
-            public string GetAllLines(string prefix) => string.Join(Environment.NewLine, _lines.Select(l => prefix + l));
         }
     }
 }

--- a/src/Microsoft.DotNet.Watcher.Tools/ProcessSpec.cs
+++ b/src/Microsoft.DotNet.Watcher.Tools/ProcessSpec.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.IO;
+using Microsoft.DotNet.Watcher.Internal;
 
 namespace Microsoft.DotNet.Watcher
 {
@@ -11,8 +12,11 @@ namespace Microsoft.DotNet.Watcher
         public string Executable { get; set; }
         public string WorkingDirectory { get; set; }
         public IEnumerable<string> Arguments { get; set; }
+        public OutputCapture OutputCapture { get; set; }
 
-        public string ShortDisplayName() 
+        public string ShortDisplayName()
             => Path.GetFileNameWithoutExtension(Executable);
+
+        public bool IsOutputCaptured => OutputCapture != null;
     }
 }

--- a/src/Microsoft.DotNet.Watcher.Tools/project.json
+++ b/src/Microsoft.DotNet.Watcher.Tools/project.json
@@ -32,7 +32,6 @@
     ]
   },
   "dependencies": {
-    "Microsoft.DotNet.Cli.Utils": "1.0.0-preview3-004056",
     "Microsoft.Extensions.Logging": "1.0.0",
     "Microsoft.Extensions.Logging.Console": "1.0.0",
     "Microsoft.Extensions.Process.Sources": {

--- a/src/Shared/ArgumentEscaper.cs
+++ b/src/Shared/ArgumentEscaper.cs
@@ -1,0 +1,107 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Microsoft.Extensions.Tools.Internal
+{
+    public static class ArgumentEscaper
+    {
+        /// <summary>
+        /// Undo the processing which took place to create string[] args in Main, so that the next process will
+        /// receive the same string[] args.
+        /// </summary>
+        /// <remarks>
+        /// See https://blogs.msdn.microsoft.com/twistylittlepassagesallalike/2011/04/23/everyone-quotes-command-line-arguments-the-wrong-way/
+        /// </remarks>
+        /// <param name="args"></param>
+        /// <returns></returns>
+        public static string EscapeAndConcatenate(IEnumerable<string> args)
+            => string.Join(" ", args.Select(EscapeSingleArg));
+
+        private static string EscapeSingleArg(string arg)
+        {
+            var sb = new StringBuilder();
+
+            var needsQuotes = ShouldSurroundWithQuotes(arg);
+            var isQuoted = needsQuotes || IsSurroundedWithQuotes(arg);
+
+            if (needsQuotes)
+            {
+                sb.Append('"');
+            }
+
+            for (int i = 0; i < arg.Length; ++i)
+            {
+                var backslashes = 0;
+
+                // Consume all backslashes
+                while (i < arg.Length && arg[i] == '\\')
+                {
+                    backslashes++;
+                    i++;
+                }
+
+                if (i == arg.Length && isQuoted)
+                {
+                    // Escape any backslashes at the end of the arg when the argument is also quoted.
+                    // This ensures the outside quote is interpreted as an argument delimiter
+                    sb.Append('\\', 2 * backslashes);
+                }
+                else if (i == arg.Length)
+                {
+                    // At then end of the arg, which isn't quoted,
+                    // just add the backslashes, no need to escape
+                    sb.Append('\\', backslashes);
+                }
+                else if (arg[i] == '"')
+                {
+                    // Escape any preceding backslashes and the quote
+                    sb.Append('\\', (2 * backslashes) + 1);
+                    sb.Append('"');
+                }
+                else
+                {
+                    // Output any consumed backslashes and the character
+                    sb.Append('\\', backslashes);
+                    sb.Append(arg[i]);
+                }
+            }
+
+            if (needsQuotes)
+            {
+                sb.Append('"');
+            }
+
+            return sb.ToString();
+        }
+
+        private static bool ShouldSurroundWithQuotes(string argument)
+        {
+            // Don't quote already quoted strings
+            if (IsSurroundedWithQuotes(argument))
+            {
+                return false;
+            }
+
+            // Only quote if whitespace exists in the string
+            return ContainsWhitespace(argument);
+        }
+
+        private static bool IsSurroundedWithQuotes(string argument)
+        {
+            if (argument.Length <= 1)
+            {
+                return false;
+            }
+
+            return argument[0] == '"' && argument[argument.Length - 1] == '"';
+        }
+
+        private static bool ContainsWhitespace(string argument)
+            => argument.IndexOfAny(new [] { ' ', '\t', '\n' }) >= 0;
+    }
+}

--- a/src/Shared/DotNetMuxer.cs
+++ b/src/Shared/DotNetMuxer.cs
@@ -1,0 +1,56 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using System.Runtime.InteropServices;
+
+namespace Microsoft.Extensions.Tools.Internal
+{
+    public static class DotNetMuxer
+    {
+        private const string MuxerName = "dotnet";
+
+        static DotNetMuxer()
+        {
+            MuxerPath = TryFindMuxerPath();
+        }
+
+        public static string MuxerPath { get; }
+
+        public static string MuxerPathOrDefault()
+            => MuxerPath ?? MuxerName;
+
+        private static string TryFindMuxerPath()
+        {
+            var fileName = MuxerName;
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                fileName += ".exe";
+            }
+
+            var fxDepsFile = AppContext.GetData("FX_DEPS_FILE") as string;
+
+            if (string.IsNullOrEmpty(fxDepsFile))
+            {
+                return null;
+            }
+
+            var muxerDir = new FileInfo(fxDepsFile) // Microsoft.NETCore.App.deps.json
+                .Directory? // (version)
+                .Parent? // Microsoft.NETCore.App
+                .Parent? // shared
+                .Parent; // DOTNET_HOME
+
+            if (muxerDir == null)
+            {
+                return null;
+            }
+
+            var muxer = Path.Combine(muxerDir.FullName, fileName);
+            return File.Exists(muxer)
+                ? muxer
+                : null;
+        }
+    }
+}

--- a/src/Shared/StringExtensions.cs
+++ b/src/Shared/StringExtensions.cs
@@ -1,0 +1,35 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace System
+{
+    public static class StringExtensions
+    {
+        public static string Black(this string text)
+            => "\x1B[30m" + text + "\x1B[39m";
+
+        public static string Red(this string text)
+            => "\x1B[31m" + text + "\x1B[39m";
+
+        public static string Green(this string text)
+            => "\x1B[32m" + text + "\x1B[39m";
+
+        public static string Yellow(this string text)
+            => "\x1B[33m" + text + "\x1B[39m";
+
+        public static string Blue(this string text)
+            => "\x1B[34m" + text + "\x1B[39m";
+
+        public static string Magenta(this string text)
+            => "\x1B[35m" + text + "\x1B[39m";
+
+        public static string Cyan(this string text)
+            => "\x1B[36m" + text + "\x1B[39m";
+
+        public static string White(this string text)
+            => "\x1B[37m" + text + "\x1B[39m";
+
+        public static string Bold(this string text)
+            => "\x1B[1m" + text + "\x1B[22m";
+    }
+}

--- a/test/Microsoft.DotNet.Watcher.Tools.FunctionalTests/project.json
+++ b/test/Microsoft.DotNet.Watcher.Tools.FunctionalTests/project.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "dotnet-test-xunit": "2.2.0-preview2-build1029",
+    "Microsoft.DotNet.Cli.Utils": "1.0.0-preview3-004056",
     "Microsoft.DotNet.InternalAbstractions": "1.0.0",
     "Microsoft.AspNetCore.Testing": "1.0.0",
     "Microsoft.DotNet.Watcher.Tools": "1.0.0-*",

--- a/test/Microsoft.DotNet.Watcher.Tools.Tests/ArgumentEscaperTests.cs
+++ b/test/Microsoft.DotNet.Watcher.Tools.Tests/ArgumentEscaperTests.cs
@@ -1,0 +1,23 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.Extensions.Tools.Internal;
+using Xunit;
+
+namespace Microsoft.DotNet.Watcher.Tools.Tests
+{
+    public class ArgumentEscaperTests
+    {
+        [Theory]
+        [InlineData(new[] { "one", "two", "three" }, "one two three")]
+        [InlineData(new[] { "line1\nline2", "word1\tword2" }, "\"line1\nline2\" \"word1\tword2\"")]
+        [InlineData(new[] { "with spaces" }, "\"with spaces\"")]
+        [InlineData(new[] { @"with\backslash" }, @"with\backslash")]
+        [InlineData(new[] { @"""quotedwith\backslash""" }, @"\""quotedwith\backslash\""")]
+        [InlineData(new[] { @"C:\Users\" }, @"C:\Users\")]
+        [InlineData(new[] { @"C:\Program Files\dotnet\" }, @"""C:\Program Files\dotnet\\""")]
+        [InlineData(new[] { @"backslash\""preceedingquote" }, @"backslash\\\""preceedingquote")]
+        public void EscapesArguments(string[] args, string expected)
+            => Assert.Equal(expected, ArgumentEscaper.EscapeAndConcatenate(args));
+    }
+}

--- a/test/Microsoft.DotNet.Watcher.Tools.Tests/CommandLineOptionsTests.cs
+++ b/test/Microsoft.DotNet.Watcher.Tools.Tests/CommandLineOptionsTests.cs
@@ -6,7 +6,7 @@ using System.Linq;
 using System.Text;
 using Xunit;
 
-namespace Microsoft.DotNet.Watcher.Tools.FunctionalTests
+namespace Microsoft.DotNet.Watcher.Tools.Tests
 {
     public class CommandLineOptionsTests
     {

--- a/test/Microsoft.DotNet.Watcher.Tools.Tests/MsBuildFileSetFactoryTest.cs
+++ b/test/Microsoft.DotNet.Watcher.Tools.Tests/MsBuildFileSetFactoryTest.cs
@@ -264,7 +264,9 @@ namespace Microsoft.DotNetWatcher.Tools.Tests
 
             var fileset = await GetFileSet(filesetFactory);
 
-            _logger.LogInformation(output.Current.GetAllLines("Sink output: "));
+            _logger.LogInformation(string.Join(
+                Environment.NewLine,
+                output.Current.Lines.Select(l => "Sink output: " + l)));
 
             var includedProjects = new[] { "A", "B", "C", "D", "E", "F", "G" };
             AssertEx.EqualFileList(


### PR DESCRIPTION
dotnet-watch doesn't really need Microsoft.DotNet.Cli.Utils. This PR trims the dependency because dotnet-watch uses only a very small portion of the API.

This will also allow us to (potentially) create dotnet-watch for net451 (Microsoft.DotNet.Cli.Utils requires net46).

cc @prafullbhosale @cesarbs 