### PR TITLE
Use MSBuild project extensions instead of importing the users project

### DIFF
--- a/src/Microsoft.Extensions.SecretManager.Tools/Microsoft.Extensions.SecretManager.Tools.nuspec
+++ b/src/Microsoft.Extensions.SecretManager.Tools/Microsoft.Extensions.SecretManager.Tools.nuspec
@@ -23,7 +23,6 @@
   </metadata>
   <files>
     <file src="prefercliruntime" target="\prefercliruntime" />
-    <file src="toolassets\FindUserSecretsProperty.targets" target="toolassets\" />
     <file src="dotnet-user-secrets.dll" target="lib\netcoreapp1.0\" />
     <file src="dotnet-user-secrets.deps.json" target="lib\netcoreapp1.0\" />
     <file src="dotnet-user-secrets.runtimeconfig.json" target="lib\netcoreapp1.0\" />

--- a/src/Microsoft.Extensions.SecretManager.Tools/Program.cs
+++ b/src/Microsoft.Extensions.SecretManager.Tools/Program.cs
@@ -124,10 +124,8 @@ namespace Microsoft.Extensions.SecretManager.Tools
                 return options.Id;
             }
 
-            using (var resolver = new ProjectIdResolver(reporter, _workingDirectory))
-            {
-                return resolver.Resolve(options.Project, options.Configuration);
-            }
+            var resolver = new ProjectIdResolver(reporter, _workingDirectory);
+            return resolver.Resolve(options.Project, options.Configuration);
         }
     }
 }

--- a/src/Microsoft.Extensions.SecretManager.Tools/project.json
+++ b/src/Microsoft.Extensions.SecretManager.Tools/project.json
@@ -5,16 +5,17 @@
     "emitEntryPoint": true,
     "warningsAsErrors": true,
     "keyFile": "../../tools/Key.snk",
-    "copyToOutput": "toolassets/*.targets",
+    "embed": {
+      "mappings": {
+        "ProjectIdResolverTargets.xml": "./resources/ProjectIdResolverTargets.xml"
+      }
+    },
     "compile": {
       "include": "../Shared/**/*.cs"
     }
   },
   "publishOptions": {
-    "include": [
-      "toolassets/*.targets",
-      "prefercliruntime"
-    ]
+    "include": "prefercliruntime"
   },
   "dependencies": {
     "Microsoft.Extensions.Configuration.UserSecrets": "1.0.0",

--- a/src/Microsoft.Extensions.SecretManager.Tools/resources/ProjectIdResolverTargets.xml
+++ b/src/Microsoft.Extensions.SecretManager.Tools/resources/ProjectIdResolverTargets.xml
@@ -1,0 +1,5 @@
+<Project>
+    <Target Name="_ExtractUserSecretsMetadata">
+        <WriteLinesToFile File="$(_UserSecretsMetadataFile)" Lines="$(UserSecretsId)" />
+    </Target>
+</Project>

--- a/src/Microsoft.Extensions.SecretManager.Tools/toolassets/FindUserSecretsProperty.targets
+++ b/src/Microsoft.Extensions.SecretManager.Tools/toolassets/FindUserSecretsProperty.targets
@@ -1,6 +1,0 @@
-<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-    <Import Project="$(Project)" />
-    <Target Name="_FindUserSecretsProperty">
-        <WriteLinesToFile File="$(OutputFile)" Lines="$(UserSecretsId)" />
-    </Target>
-</Project>

--- a/test/Microsoft.Extensions.SecretManager.Tools.Tests/UserSecretsTestFixture.cs
+++ b/test/Microsoft.Extensions.SecretManager.Tools.Tests/UserSecretsTestFixture.cs
@@ -32,9 +32,7 @@ namespace Microsoft.Extensions.Configuration.UserSecrets.Tests
             return GetTempSecretProject(out userSecretsId);
         }
 
-        private const string ProjectTemplate = @"<Project ToolsVersion=""14.0"" xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
-  <Import Project=""$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props"" />
-
+        private const string ProjectTemplate = @"<Project ToolsVersion=""15.0"" Sdk=""Microsoft.NET.Sdk"">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFrameworks>netcoreapp1.0</TargetFrameworks>
@@ -43,12 +41,8 @@ namespace Microsoft.Extensions.Configuration.UserSecrets.Tests
 
   <ItemGroup>
     <Compile Include=""**\*.cs"" Exclude=""Excluded.cs"" />
-
-    <PackageReference Include=""Microsoft.NET.Sdk"" Version=""1.0.0-*"" PrivateAssets=""All"" />
     <PackageReference Include=""Microsoft.NETCore.App"" Version=""1.0.1"" />
   </ItemGroup>
-
-  <Import Project=""$(MSBuildToolsPath)\Microsoft.CSharp.targets"" />
 </Project>";
 
         public string GetTempSecretProject(out string userSecretsId)


### PR DESCRIPTION
Implicit imports prevents using <Import> on a project file that has the Sdk attribute. This change instead generates a file in the MSBuildProjectExtensionsPath to inject targets require to find the UserSecretsId property in a project. (This is the approached used by dotnet-watch and dotnet-ef).

Resolves #242 

cc @mlorbetske @muratg 
cc @bricelam can you review? This is similar to the approach you've implemented in dotnet-ef to extract project metadata.