### PR TITLE
Set dotnet-watch env variable on inner process

### DIFF
--- a/src/Microsoft.DotNet.Watcher.Tools/Internal/ProcessRunner.cs
+++ b/src/Microsoft.DotNet.Watcher.Tools/Internal/ProcessRunner.cs
@@ -63,20 +63,25 @@ namespace Microsoft.DotNet.Watcher.Internal
 
         private Process CreateProcess(ProcessSpec processSpec)
         {
-            var startInfo = new ProcessStartInfo
-            {
-                FileName = processSpec.Executable,
-                Arguments = ArgumentEscaper.EscapeAndConcatenate(processSpec.Arguments),
-                UseShellExecute = false,
-                WorkingDirectory = processSpec.WorkingDirectory,
-                RedirectStandardOutput = processSpec.IsOutputCaptured,
-                RedirectStandardError = processSpec.IsOutputCaptured,
-            };
             var process = new Process
             {
-                StartInfo = startInfo,
-                EnableRaisingEvents = true
+                EnableRaisingEvents = true,
+                StartInfo =
+                {
+                    FileName = processSpec.Executable,
+                    Arguments = ArgumentEscaper.EscapeAndConcatenate(processSpec.Arguments),
+                    UseShellExecute = false,
+                    WorkingDirectory = processSpec.WorkingDirectory,
+                    RedirectStandardOutput = processSpec.IsOutputCaptured,
+                    RedirectStandardError = processSpec.IsOutputCaptured,
+                }
             };
+
+            foreach (var env in processSpec.EnvironmentVariables)
+            {
+                process.StartInfo.Environment.Add(env.Key, env.Value);
+            }
+
             return process;
         }
 

--- a/src/Microsoft.DotNet.Watcher.Tools/ProcessSpec.cs
+++ b/src/Microsoft.DotNet.Watcher.Tools/ProcessSpec.cs
@@ -11,6 +11,7 @@ namespace Microsoft.DotNet.Watcher
     {
         public string Executable { get; set; }
         public string WorkingDirectory { get; set; }
+        public IDictionary<string, string> EnvironmentVariables { get; } = new Dictionary<string, string>();
         public IEnumerable<string> Arguments { get; set; }
         public OutputCapture OutputCapture { get; set; }
 

--- a/src/Microsoft.DotNet.Watcher.Tools/Program.cs
+++ b/src/Microsoft.DotNet.Watcher.Tools/Program.cs
@@ -133,7 +133,11 @@ namespace Microsoft.DotNet.Watcher
             {
                 Executable = DotNetMuxer.MuxerPathOrDefault(),
                 WorkingDirectory = Path.GetDirectoryName(projectFile),
-                Arguments = args
+                Arguments = args,
+                EnvironmentVariables =
+                {
+                    ["DOTNET_WATCH"] = "1"
+                },
             };
 
             await new DotNetWatcher(reporter)

--- a/test/Microsoft.DotNet.Watcher.Tools.FunctionalTests/DotNetWatcherTests.cs
+++ b/test/Microsoft.DotNet.Watcher.Tools.FunctionalTests/DotNetWatcherTests.cs
@@ -1,0 +1,46 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.DotNet.Watcher.Tools.FunctionalTests
+{
+    public class DotNetWatcherTests : IDisposable
+    {
+        private readonly KitchenSinkApp _app;
+
+        public DotNetWatcherTests(ITestOutputHelper logger)
+        {
+            _app = new KitchenSinkApp(logger);
+            _app.Prepare();
+        }
+
+        [Fact]
+        public async Task RunsWithDotnetWatchEnvVariable()
+        {
+            Assert.True(string.IsNullOrEmpty(Environment.GetEnvironmentVariable("DOTNET_WATCH")), "DOTNET_WATCH cannot be set already when this test is running");
+
+            await _app.StartWatcherAsync().OrTimeout();
+            const string messagePrefix = "DOTNET_WATCH = ";
+            var message = await _app.Process.GetOutputLineAsync(m => m.StartsWith(messagePrefix));
+            var envValue = message.Substring(messagePrefix.Length);
+            Assert.Equal("1", envValue);
+        }
+
+        public void Dispose()
+        {
+            _app.Dispose();
+        }
+
+        private class KitchenSinkApp : WatchableApp
+        {
+            public KitchenSinkApp(ITestOutputHelper logger)
+                : base("KitchenSink", logger)
+            {
+            }
+        }
+    }
+}

--- a/test/Microsoft.DotNet.Watcher.Tools.FunctionalTests/Scenario/WatchableApp.cs
+++ b/test/Microsoft.DotNet.Watcher.Tools.FunctionalTests/Scenario/WatchableApp.cs
@@ -93,7 +93,7 @@ namespace Microsoft.DotNet.Watcher.Tools.FunctionalTests
 
         public virtual void Dispose()
         {
-            Process.Dispose();
+            Process?.Dispose();
             Scenario.Dispose();
         }
     }

--- a/test/Microsoft.DotNet.Watcher.Tools.FunctionalTests/TestProjects/KitchenSink/KitchenSink.csproj
+++ b/test/Microsoft.DotNet.Watcher.Tools.FunctionalTests/TestProjects/KitchenSink/KitchenSink.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/test/Microsoft.DotNet.Watcher.Tools.FunctionalTests/TestProjects/KitchenSink/Program.cs
+++ b/test/Microsoft.DotNet.Watcher.Tools.FunctionalTests/TestProjects/KitchenSink/Program.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Diagnostics;
+
+namespace KitchenSink
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            Console.WriteLine("Started");
+            Console.WriteLine("PID = " + Process.GetCurrentProcess().Id);
+            Console.WriteLine("DOTNET_WATCH = " + Environment.GetEnvironmentVariable("DOTNET_WATCH"));
+        }
+    }
+}


### PR DESCRIPTION
Makes it possible to detect when running inside dotnet-watch by setting 'DOTNET_WATCH=1'

Resolves #52