### PR TITLE
1.0.1: More logging and timeouts in dotnet-watch tests

### DIFF
--- a/test/Microsoft.DotNet.Watcher.Tools.FunctionalTests/AppWithDepsTests.cs
+++ b/test/Microsoft.DotNet.Watcher.Tools.FunctionalTests/AppWithDepsTests.cs
@@ -16,13 +16,12 @@ namespace Microsoft.DotNet.Watcher.Tools.FunctionalTests
         public AppWithDepsTests(ITestOutputHelper logger)
         {
             _app = new AppWithDeps(logger);
-            _app.Prepare();
         }
 
         [Fact]
         public async Task ChangeFileInDependency()
         {
-            await _app.StartWatcherAsync().OrTimeout();
+            await _app.StartWatcherAsync();
 
             var fileToChange = Path.Combine(_app.DependencyFolder, "Foo.cs");
             var programCs = File.ReadAllText(fileToChange);

--- a/test/Microsoft.DotNet.Watcher.Tools.FunctionalTests/GlobbingAppTests.cs
+++ b/test/Microsoft.DotNet.Watcher.Tools.FunctionalTests/GlobbingAppTests.cs
@@ -17,7 +17,6 @@ namespace Microsoft.DotNet.Watcher.Tools.FunctionalTests
         public GlobbingAppTests(ITestOutputHelper logger)
         {
             _app = new GlobbingApp(logger);
-            _app.Prepare();
         }
 
         [Theory]
@@ -25,7 +24,7 @@ namespace Microsoft.DotNet.Watcher.Tools.FunctionalTests
         [InlineData(false)]
         public async Task ChangeCompiledFile(bool usePollingWatcher)
         {
-            await _app.StartWatcherAsync().OrTimeout();
+            await _app.StartWatcherAsync();
 
             var types = await _app.GetCompiledAppDefinedTypes().OrTimeout();
             Assert.Equal(2, types);
@@ -42,7 +41,7 @@ namespace Microsoft.DotNet.Watcher.Tools.FunctionalTests
         [Fact(Skip = "Broken. See https://github.com/aspnet/DotNetTools/issues/212")]
         public async Task AddCompiledFile()
         {
-            await _app.StartWatcherAsync().OrTimeout();
+            await _app.StartWatcherAsync();
 
             var types = await _app.GetCompiledAppDefinedTypes().OrTimeout();
             Assert.Equal(2, types);
@@ -58,7 +57,7 @@ namespace Microsoft.DotNet.Watcher.Tools.FunctionalTests
         [Fact]
         public async Task DeleteCompiledFile()
         {
-            await _app.StartWatcherAsync().OrTimeout();
+            await _app.StartWatcherAsync();
 
             var types = await _app.GetCompiledAppDefinedTypes().OrTimeout();
             Assert.Equal(2, types);
@@ -74,7 +73,7 @@ namespace Microsoft.DotNet.Watcher.Tools.FunctionalTests
         [Fact]
         public async Task DeleteSourceFolder()
         {
-            await _app.StartWatcherAsync().OrTimeout();
+            await _app.StartWatcherAsync();
 
             var types = await _app.GetCompiledAppDefinedTypes().OrTimeout();
             Assert.Equal(2, types);
@@ -90,7 +89,7 @@ namespace Microsoft.DotNet.Watcher.Tools.FunctionalTests
         [Fact]
         public async Task RenameCompiledFile()
         {
-            await _app.StartWatcherAsync().OrTimeout();
+            await _app.StartWatcherAsync();
 
             var oldFile = Path.Combine(_app.SourceDirectory, "include", "Foo.cs");
             var newFile = Path.Combine(_app.SourceDirectory, "include", "Foo_new.cs");
@@ -102,7 +101,7 @@ namespace Microsoft.DotNet.Watcher.Tools.FunctionalTests
         [Fact]
         public async Task ChangeExcludedFile()
         {
-            await _app.StartWatcherAsync().OrTimeout();
+            await _app.StartWatcherAsync();
 
             var changedFile = Path.Combine(_app.SourceDirectory, "exclude", "Baz.cs");
             File.WriteAllText(changedFile, "");

--- a/test/Microsoft.DotNet.Watcher.Tools.FunctionalTests/NoDepsAppTests.cs
+++ b/test/Microsoft.DotNet.Watcher.Tools.FunctionalTests/NoDepsAppTests.cs
@@ -17,13 +17,12 @@ namespace Microsoft.DotNet.Watcher.Tools.FunctionalTests
         public NoDepsAppTests(ITestOutputHelper logger)
         {
             _app = new WatchableApp("NoDepsApp", logger);
-            _app.Prepare();
         }
 
         [Fact]
         public async Task RestartProcessOnFileChange()
         {
-            await _app.StartWatcherAsync(new[] { "--no-exit" }).OrTimeout();
+            await _app.StartWatcherAsync(new[] { "--no-exit" });
             var pid = await _app.GetProcessId().OrTimeout();
 
             // Then wait for it to restart when we change a file
@@ -42,7 +41,7 @@ namespace Microsoft.DotNet.Watcher.Tools.FunctionalTests
         [Fact]
         public async Task RestartProcessThatTerminatesAfterFileChange()
         {
-            await _app.StartWatcherAsync().OrTimeout();
+            await _app.StartWatcherAsync();
             var pid = await _app.GetProcessId().OrTimeout();
             await _app.HasExited().OrTimeout(); // process should exit after run
 


### PR DESCRIPTION
Tests can hang indefinitely if dotnet-restore or dotnet-build on the test apps fails to exit.

Resolves #290 