### PR TITLE
Remove blocking call to stream reader and fix bug in task chaining

### DIFF
--- a/build/repo.props
+++ b/build/repo.props
@@ -1,5 +1,0 @@
-<Project>
-  <ItemGroup>
-  	<ExcludeFromTest Include="$(RepositoryRoot)test\Microsoft.DotNet.Watcher.Tools.FunctionalTests\*.csproj" />
-  </ItemGroup>
-</Project>

--- a/test/Microsoft.DotNet.Watcher.Tools.FunctionalTests/AppWithDepsTests.cs
+++ b/test/Microsoft.DotNet.Watcher.Tools.FunctionalTests/AppWithDepsTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -16,7 +16,6 @@ namespace Microsoft.DotNet.Watcher.Tools.FunctionalTests
         public AppWithDepsTests(ITestOutputHelper logger)
         {
             _app = new AppWithDeps(logger);
-            _app.Prepare();
         }
 
         [Fact]

--- a/test/Microsoft.DotNet.Watcher.Tools.FunctionalTests/GlobbingAppTests.cs
+++ b/test/Microsoft.DotNet.Watcher.Tools.FunctionalTests/GlobbingAppTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -17,7 +17,6 @@ namespace Microsoft.DotNet.Watcher.Tools.FunctionalTests
         public GlobbingAppTests(ITestOutputHelper logger)
         {
             _app = new GlobbingApp(logger);
-            _app.Prepare();
         }
 
         [Theory]
@@ -115,6 +114,7 @@ namespace Microsoft.DotNet.Watcher.Tools.FunctionalTests
         [Fact]
         public async Task ListsFiles()
         {
+            await _app.PrepareAsync();
             _app.Start(new [] { "--list" });
             var lines = await _app.Process.GetAllOutputLines();
 

--- a/test/Microsoft.DotNet.Watcher.Tools.FunctionalTests/NoDepsAppTests.cs
+++ b/test/Microsoft.DotNet.Watcher.Tools.FunctionalTests/NoDepsAppTests.cs
@@ -17,7 +17,6 @@ namespace Microsoft.DotNet.Watcher.Tools.FunctionalTests
         public NoDepsAppTests(ITestOutputHelper logger)
         {
             _app = new WatchableApp("NoDepsApp", logger);
-            _app.Prepare();
         }
 
         [Fact]

--- a/test/Microsoft.DotNet.Watcher.Tools.FunctionalTests/Scenario/WatchableApp.cs
+++ b/test/Microsoft.DotNet.Watcher.Tools.FunctionalTests/Scenario/WatchableApp.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -52,10 +52,10 @@ namespace Microsoft.DotNet.Watcher.Tools.FunctionalTests
             return int.Parse(pid);
         }
 
-        public void Prepare()
+        public async Task PrepareAsync()
         {
-            Scenario.Restore(_appName);
-            Scenario.Build(_appName);
+            await Scenario.RestoreAsync(_appName);
+            await Scenario.BuildAsync(_appName);
             _prepared = true;
         }
 
@@ -63,7 +63,7 @@ namespace Microsoft.DotNet.Watcher.Tools.FunctionalTests
         {
             if (!_prepared)
             {
-                throw new InvalidOperationException("Call .Prepare() first");
+                throw new InvalidOperationException($"Call {nameof(PrepareAsync)} first");
             }
 
             var args = Scenario
@@ -86,6 +86,11 @@ namespace Microsoft.DotNet.Watcher.Tools.FunctionalTests
 
         public async Task StartWatcherAsync(string[] arguments, [CallerMemberName] string name = null)
         {
+            if (!_prepared)
+            {
+                await PrepareAsync();
+            }
+
             var args = new[] { "run", "--" }.Concat(arguments);
             Start(args, name);
             await Process.GetOutputLineAsync(StartedMessage);
@@ -93,8 +98,8 @@ namespace Microsoft.DotNet.Watcher.Tools.FunctionalTests
 
         public virtual void Dispose()
         {
-            Process.Dispose();
-            Scenario.Dispose();
+            Process?.Dispose();
+            Scenario?.Dispose();
         }
     }
 }

--- a/test/Microsoft.DotNet.Watcher.Tools.Tests/AssertEx.cs
+++ b/test/Microsoft.DotNet.Watcher.Tools.Tests/AssertEx.cs
@@ -21,7 +21,7 @@ namespace Microsoft.DotNet.Watcher.Tools.Tests
         {
             Func<string, string> normalize = p => p.Replace('\\', '/');
             var expected = new HashSet<string>(expectedFiles.Select(normalize));
-            Assert.True(expected.SetEquals(actualFiles.Select(normalize)), "File sets should be equal");
+            Assert.True(expected.SetEquals(actualFiles.Where(p => !string.IsNullOrEmpty(p)).Select(normalize)), "File sets should be equal");
         }
     }
 }

--- a/test/Microsoft.DotNet.Watcher.Tools.Tests/Utilities/TaskExtensions.cs
+++ b/test/Microsoft.DotNet.Watcher.Tools.Tests/Utilities/TaskExtensions.cs
@@ -9,8 +9,12 @@ namespace System.Threading.Tasks
     {
         public static async Task<T> OrTimeout<T>(this Task<T> task, int timeout = 30, [CallerFilePath] string file = null, [CallerLineNumber] int line = 0)
         {
-            await OrTimeout((Task)task, timeout, file, line);
-            return task.Result;
+            var finished = await Task.WhenAny(task, Task.Delay(TimeSpan.FromSeconds(timeout)));
+            if (!ReferenceEquals(finished, task))
+            {
+                throw new TimeoutException($"Task exceeded max running time of {timeout}s at {file}:{line}");
+            }
+            return await task;
         }
 
         public static async Task OrTimeout(this Task task, int timeout = 30, [CallerFilePath] string file = null, [CallerLineNumber] int line = 0)
@@ -20,6 +24,7 @@ namespace System.Threading.Tasks
             {
                 throw new TimeoutException($"Task exceeded max running time of {timeout}s at {file}:{line}");
             }
+            await task;
         }
     }
 }


### PR DESCRIPTION
Should avoid the deadlocks caused by dotnet-restore hanging indefinitely.

Resolves #290 