### PR TITLE
Add --msbuildprojectextensionspath option to dotnet-watch

### DIFF
--- a/src/Microsoft.DotNet.Watcher.Tools/CommandLineOptions.cs
+++ b/src/Microsoft.DotNet.Watcher.Tools/CommandLineOptions.cs
@@ -12,6 +12,7 @@ namespace Microsoft.DotNet.Watcher
     internal class CommandLineOptions
     {
         public string Project { get; private set; }
+        public string MSBuildProjectExtensionsPath { get; private set; }
         public bool IsHelp { get; private set; }
         public bool IsQuiet { get; private set; }
         public bool IsVerbose { get; private set; }
@@ -61,8 +62,16 @@ Examples:
             };
 
             app.HelpOption("-?|-h|--help");
-            var optProjects = app.Option("-p|--project", "The project to watch",
-                CommandOptionType.SingleValue); // TODO multiple shouldn't be too hard to support
+            // TODO multiple shouldn't be too hard to support
+            var optProjects = app.Option("-p|--project <PROJECT>", "The project to watch",
+                CommandOptionType.SingleValue);
+
+            var optMSBuildProjectExtensionsPath = app.Option("--msbuildprojectextensionspath <PATH>",
+                "The MSBuild project extensions path. Defaults to \"obj\".",
+                CommandOptionType.SingleValue);
+            // Hide from help text because this is an internal option that will hopefully go away when/if #244 is resolved.
+            optMSBuildProjectExtensionsPath.ShowInHelpText = false;
+
             var optQuiet = app.Option("-q|--quiet", "Suppresses all output except warnings and errors",
                 CommandOptionType.NoValue);
             var optVerbose = app.VerboseOption();
@@ -92,6 +101,7 @@ Examples:
             return new CommandLineOptions
             {
                 Project = optProjects.Value(),
+                MSBuildProjectExtensionsPath = optMSBuildProjectExtensionsPath.Value(),
                 IsQuiet = optQuiet.HasValue(),
                 IsVerbose = optVerbose.HasValue(),
                 RemainingArguments = app.RemainingArguments,

--- a/src/Microsoft.DotNet.Watcher.Tools/Program.cs
+++ b/src/Microsoft.DotNet.Watcher.Tools/Program.cs
@@ -81,12 +81,14 @@ namespace Microsoft.DotNet.Watcher
                 {
                     return await ListFilesAsync(_reporter,
                         options.Project,
+                        options.MSBuildProjectExtensionsPath,
                         _cts.Token);
                 }
                 else
                 {
                     return await MainInternalAsync(_reporter,
                         options.Project,
+                        options.MSBuildProjectExtensionsPath,
                         options.RemainingArguments,
                         _cts.Token);
                 }
@@ -121,6 +123,7 @@ namespace Microsoft.DotNet.Watcher
         private async Task<int> MainInternalAsync(
             IReporter reporter,
             string project,
+            string msbuildProjectExtensionsPath,
             ICollection<string> args,
             CancellationToken cancellationToken)
         {
@@ -136,7 +139,10 @@ namespace Microsoft.DotNet.Watcher
                 return 1;
             }
 
-            var fileSetFactory = new MsBuildFileSetFactory(reporter, projectFile, waitOnError: true);
+            var fileSetFactory = new MsBuildFileSetFactory(reporter,
+                projectFile,
+                NormalizePath(msbuildProjectExtensionsPath),
+                waitOnError: true);
             var processInfo = new ProcessSpec
             {
                 Executable = DotNetMuxer.MuxerPathOrDefault(),
@@ -157,6 +163,7 @@ namespace Microsoft.DotNet.Watcher
         private async Task<int> ListFilesAsync(
             IReporter reporter,
             string project,
+            string msbuildProjectExtensionsPath,
             CancellationToken cancellationToken)
         {
             // TODO multiple projects should be easy enough to add here
@@ -171,7 +178,10 @@ namespace Microsoft.DotNet.Watcher
                 return 1;
             }
 
-            var fileSetFactory = new MsBuildFileSetFactory(reporter, projectFile, waitOnError: false);
+            var fileSetFactory = new MsBuildFileSetFactory(reporter,
+                projectFile,
+                NormalizePath(msbuildProjectExtensionsPath),
+                waitOnError: false);
             var files = await fileSetFactory.CreateAsync(cancellationToken);
 
             if (files == null)
@@ -189,6 +199,22 @@ namespace Microsoft.DotNet.Watcher
 
         private static IReporter CreateReporter(bool verbose, bool quiet, IConsole console)
             => new PrefixConsoleReporter(console, verbose || CliContext.IsGlobalVerbose(), quiet);
+
+
+        private string NormalizePath(string path)
+        {
+            if (path == null || Path.IsPathRooted(path))
+            {
+                return path;
+            }
+
+            if (string.IsNullOrWhiteSpace(path))
+            {
+                return _workingDir;
+            }
+
+            return Path.Combine(_workingDir, path);
+        }
 
         public void Dispose()
         {

--- a/test/Microsoft.DotNet.Watcher.Tools.FunctionalTests/DotNetWatcherTests.cs
+++ b/test/Microsoft.DotNet.Watcher.Tools.FunctionalTests/DotNetWatcherTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
@@ -39,6 +40,11 @@ namespace Microsoft.DotNet.Watcher.Tools.FunctionalTests
             public KitchenSinkApp(ITestOutputHelper logger)
                 : base("KitchenSink", logger)
             {
+            }
+
+            protected override IEnumerable<string> GetDefaultArgs()
+            {
+                return new[] { "--msbuildprojectextensionspath", ".net/obj", "run", "--" };
             }
         }
     }

--- a/test/Microsoft.DotNet.Watcher.Tools.FunctionalTests/Scenario/WatchableApp.cs
+++ b/test/Microsoft.DotNet.Watcher.Tools.FunctionalTests/Scenario/WatchableApp.cs
@@ -96,12 +96,17 @@ namespace Microsoft.DotNet.Watcher.Tools.FunctionalTests
                 await PrepareAsync();
             }
 
-            var args = new[] { "run", "--" }.Concat(arguments);
+            var args = GetDefaultArgs().Concat(arguments);
             Start(args, name);
 
             // Make this timeout long because it depends much on the MSBuild compilation speed.
             // Slow machines may take a bit to compile and boot test apps
             await Process.GetOutputLineAsync(StartedMessage).TimeoutAfter(TimeSpan.FromMinutes(2));
+        }
+
+        protected virtual IEnumerable<string> GetDefaultArgs()
+        {
+            return new[] { "run", "--" };
         }
 
         public virtual void Dispose()

--- a/test/Microsoft.DotNet.Watcher.Tools.FunctionalTests/TestProjects/KitchenSink/KitchenSink.csproj
+++ b/test/Microsoft.DotNet.Watcher.Tools.FunctionalTests/TestProjects/KitchenSink/KitchenSink.csproj
@@ -1,8 +1,16 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<Project>
+
+  <PropertyGroup>
+    <BaseIntermediateOutputPath>.net/obj</BaseIntermediateOutputPath>
+  </PropertyGroup>
+
+  <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
+
+  <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
 
 </Project>

--- a/test/Microsoft.DotNet.Watcher.Tools.Tests/MsBuildFileSetFactoryTest.cs
+++ b/test/Microsoft.DotNet.Watcher.Tools.Tests/MsBuildFileSetFactoryTest.cs
@@ -238,7 +238,7 @@ namespace Microsoft.DotNet.Watcher.Tools.Tests
             graph.Find("A").WithProjectReference(graph.Find("W"), watch: false);
 
             var output = new OutputSink();
-            var filesetFactory = new MsBuildFileSetFactory(_reporter, graph.GetOrCreate("A").Path, output)
+            var filesetFactory = new MsBuildFileSetFactory(_reporter, graph.GetOrCreate("A").Path, null, output)
             {
                 // enables capturing markers to know which projects have been visited
                 BuildFlags = { "/p:_DotNetWatchTraceOutput=true" }
@@ -280,7 +280,7 @@ namespace Microsoft.DotNet.Watcher.Tools.Tests
         }
 
         private Task<IFileSet> GetFileSet(TemporaryCSharpProject target)
-            => GetFileSet(new MsBuildFileSetFactory(_reporter, target.Path, waitOnError: false));
+            => GetFileSet(new MsBuildFileSetFactory(_reporter, target.Path, null, waitOnError: false));
 
         private async Task<IFileSet> GetFileSet(MsBuildFileSetFactory filesetFactory)
         {


### PR DESCRIPTION
In the event someone wants to move the obj/ folder, MSBuild will not be able to locate dotnet-watch's generated targets. dotnet-watch cannot automatically find the obj folder (#244), so this command line switch allows users to point dotnet-watch to the right location.