### PR TITLE
Set "TreatWarningsAsErrors" before NuGet restore

### DIFF
--- a/build/common.props
+++ b/build/common.props
@@ -10,7 +10,8 @@
     <SignAssembly>true</SignAssembly>
     <PublicSign Condition="'$(OS)' != 'Windows_NT'">true</PublicSign>
     <VersionSuffix Condition="'$(VersionSuffix)'!='' AND '$(BuildNumber)' != ''">$(VersionSuffix)-$(BuildNumber)</VersionSuffix>
-
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    
     <!-- Binary compatiblity is not a goal for command-line tools. -->
     <EnableApiCheck>false</EnableApiCheck>
   </PropertyGroup>


### PR DESCRIPTION
* Ensures our build stays clean of NuGet warnings