### PR TITLE
Fix StackOverflowException when watching directories on network shares

### DIFF
--- a/shared/NullReporter.cs
+++ b/shared/NullReporter.cs
@@ -1,0 +1,25 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.Extensions.Tools.Internal
+{
+    public class NullReporter : IReporter
+    {
+        private NullReporter()
+        { }
+
+        public static IReporter Singleton { get; } = new NullReporter();
+
+        public void Verbose(string message)
+        { }
+
+        public void Output(string message)
+        { }
+
+        public void Warn(string message)
+        { }
+
+        public void Error(string message)
+        { }
+    }
+}

--- a/src/Microsoft.DotNet.Watcher.Tools/CommandLineOptions.cs
+++ b/src/Microsoft.DotNet.Watcher.Tools/CommandLineOptions.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Reflection;
 using Microsoft.DotNet.Watcher.Tools;
@@ -18,6 +19,17 @@ namespace Microsoft.DotNet.Watcher
         public bool IsVerbose { get; private set; }
         public IList<string> RemainingArguments { get; private set; }
         public bool ListFiles { get; private set; }
+
+        public static bool IsPollingEnabled
+        {
+            get
+            {
+                var envVar = Environment.GetEnvironmentVariable("DOTNET_USE_POLLING_FILE_WATCHER");
+                return envVar != null &&
+                    (envVar.Equals("1", StringComparison.OrdinalIgnoreCase) ||
+                     envVar.Equals("true", StringComparison.OrdinalIgnoreCase));
+            }
+        }
 
         public static CommandLineOptions Parse(string[] args, IConsole console)
         {

--- a/src/Microsoft.DotNet.Watcher.Tools/DotNetWatcher.cs
+++ b/src/Microsoft.DotNet.Watcher.Tools/DotNetWatcher.cs
@@ -51,7 +51,7 @@ namespace Microsoft.DotNet.Watcher
                 using (var combinedCancellationSource = CancellationTokenSource.CreateLinkedTokenSource(
                     cancellationToken,
                     currentRunCancellationSource.Token))
-                using (var fileSetWatcher = new FileSetWatcher(fileSet))
+                using (var fileSetWatcher = new FileSetWatcher(fileSet, _reporter))
                 {
                     var fileSetTask = fileSetWatcher.GetChangedFileAsync(combinedCancellationSource.Token);
                     var processTask = _processRunner.RunAsync(processSpec, combinedCancellationSource.Token);

--- a/src/Microsoft.DotNet.Watcher.Tools/Internal/FileSetWatcher.cs
+++ b/src/Microsoft.DotNet.Watcher.Tools/Internal/FileSetWatcher.cs
@@ -11,14 +11,15 @@ namespace Microsoft.DotNet.Watcher.Internal
 {
     public class FileSetWatcher : IDisposable
     {
-        private readonly FileWatcher _fileWatcher = new FileWatcher();
+        private readonly FileWatcher _fileWatcher;
         private readonly IFileSet _fileSet;
 
-        public FileSetWatcher(IFileSet fileSet)
+        public FileSetWatcher(IFileSet fileSet, IReporter reporter)
         {
             Ensure.NotNull(fileSet, nameof(fileSet));
 
             _fileSet = fileSet;
+            _fileWatcher = new FileWatcher(reporter);
         }
 
         public async Task<string> GetChangedFileAsync(CancellationToken cancellationToken)

--- a/src/Microsoft.DotNet.Watcher.Tools/Internal/FileWatcher/FileWatcherFactory.cs
+++ b/src/Microsoft.DotNet.Watcher.Tools/Internal/FileWatcher/FileWatcherFactory.cs
@@ -8,15 +8,7 @@ namespace Microsoft.DotNet.Watcher.Internal
     public static class FileWatcherFactory
     {
         public static IFileSystemWatcher CreateWatcher(string watchedDirectory)
-        {
-            var envVar = Environment.GetEnvironmentVariable("DOTNET_USE_POLLING_FILE_WATCHER");
-            var usePollingWatcher =
-                envVar != null &&
-                (envVar.Equals("1", StringComparison.OrdinalIgnoreCase) ||
-                 envVar.Equals("true", StringComparison.OrdinalIgnoreCase));
-
-            return CreateWatcher(watchedDirectory, usePollingWatcher);
-        }
+            => CreateWatcher(watchedDirectory, CommandLineOptions.IsPollingEnabled);
 
         public static IFileSystemWatcher CreateWatcher(string watchedDirectory, bool usePollingWatcher)
         {

--- a/src/Microsoft.DotNet.Watcher.Tools/Internal/FileWatcher/IFileSystemWatcher.cs
+++ b/src/Microsoft.DotNet.Watcher.Tools/Internal/FileWatcher/IFileSystemWatcher.cs
@@ -9,7 +9,9 @@ namespace Microsoft.DotNet.Watcher.Internal
     {
         event EventHandler<string> OnFileChange;
 
-        event EventHandler OnError;
+        event EventHandler<Exception> OnError;
+
+        string BasePath { get; }
 
         bool EnableRaisingEvents { get; set; }
     }

--- a/src/Microsoft.DotNet.Watcher.Tools/Internal/FileWatcher/PollingFileWatcher.cs
+++ b/src/Microsoft.DotNet.Watcher.Tools/Internal/FileWatcher/PollingFileWatcher.cs
@@ -31,6 +31,7 @@ namespace Microsoft.DotNet.Watcher.Internal
             Ensure.NotNullOrEmpty(watchedDirectory, nameof(watchedDirectory));
 
             _watchedDirectory = new DirectoryInfo(watchedDirectory);
+            BasePath = _watchedDirectory.FullName;
 
             _pollingThread = new Thread(new ThreadStart(PollingLoop));
             _pollingThread.IsBackground = true;
@@ -44,15 +45,14 @@ namespace Microsoft.DotNet.Watcher.Internal
         public event EventHandler<string> OnFileChange;
 
 #pragma warning disable CS0067 // not used
-        public event EventHandler OnError;
+        public event EventHandler<Exception> OnError;
 #pragma warning restore
+
+        public string BasePath { get; }
 
         public bool EnableRaisingEvents
         {
-            get
-            {
-                return _raiseEvents;
-            }
+            get => _raiseEvents;
             set
             {
                 EnsureNotDisposed();
@@ -125,7 +125,7 @@ namespace Microsoft.DotNet.Watcher.Internal
 
                         _knownEntities[fullFilePath] = new FileMeta(fileMeta.FileInfo, true);
                     }
-                    catch(FileNotFoundException)
+                    catch (FileNotFoundException)
                     {
                         _knownEntities[fullFilePath] = new FileMeta(fileMeta.FileInfo, false);
                     }
@@ -187,7 +187,7 @@ namespace Microsoft.DotNet.Watcher.Internal
             {
                 return;
             }
-            
+
             var entities = dirInfo.EnumerateFileSystemInfos("*.*");
             foreach (var entity in entities)
             {

--- a/src/Microsoft.DotNet.Watcher.Tools/Internal/MsBuildFileSetFactory.cs
+++ b/src/Microsoft.DotNet.Watcher.Tools/Internal/MsBuildFileSetFactory.cs
@@ -144,7 +144,7 @@ namespace Microsoft.DotNet.Watcher.Internal
 
                         var fileSet = new FileSet(new[] { _projectFile });
 
-                        using (var watcher = new FileSetWatcher(fileSet))
+                        using (var watcher = new FileSetWatcher(fileSet, _reporter))
                         {
                             await watcher.GetChangedFileAsync(cancellationToken);
 

--- a/src/Microsoft.DotNet.Watcher.Tools/Program.cs
+++ b/src/Microsoft.DotNet.Watcher.Tools/Program.cs
@@ -160,6 +160,11 @@ namespace Microsoft.DotNet.Watcher
                 },
             };
 
+            if (CommandLineOptions.IsPollingEnabled)
+            {
+                _reporter.Output("Polling file watcher is enabled");
+            }
+
             await new DotNetWatcher(reporter)
                 .WatchAsync(processInfo, fileSetFactory, cancellationToken);
 


### PR DESCRIPTION
Resolves #321 

Furthermore, I've added some additional console output to help us find these errors in the future. For example, when the non-polling watcher is used on a network share, users will now see warning that there was a problem watching that folder.

![image](https://user-images.githubusercontent.com/2696087/28225524-db45480e-6887-11e7-9b7e-cd49ada257b9.png)


cc @bruce31