### PR TITLE
Remove redundant calls to .OrTimeout()

### DIFF
--- a/test/Microsoft.DotNet.Watcher.Tools.FunctionalTests/AppWithDepsTests.cs
+++ b/test/Microsoft.DotNet.Watcher.Tools.FunctionalTests/AppWithDepsTests.cs
@@ -21,13 +21,13 @@ namespace Microsoft.DotNet.Watcher.Tools.FunctionalTests
         [Fact]
         public async Task ChangeFileInDependency()
         {
-            await _app.StartWatcherAsync().OrTimeout();
+            await _app.StartWatcherAsync();
 
             var fileToChange = Path.Combine(_app.DependencyFolder, "Foo.cs");
             var programCs = File.ReadAllText(fileToChange);
             File.WriteAllText(fileToChange, programCs);
 
-            await _app.HasRestarted().OrTimeout();
+            await _app.HasRestarted();
         }
 
         public void Dispose()

--- a/test/Microsoft.DotNet.Watcher.Tools.FunctionalTests/GlobbingAppTests.cs
+++ b/test/Microsoft.DotNet.Watcher.Tools.FunctionalTests/GlobbingAppTests.cs
@@ -24,84 +24,84 @@ namespace Microsoft.DotNet.Watcher.Tools.FunctionalTests
         [InlineData(false)]
         public async Task ChangeCompiledFile(bool usePollingWatcher)
         {
-            await _app.StartWatcherAsync().OrTimeout();
+            await _app.StartWatcherAsync();
 
-            var types = await _app.GetCompiledAppDefinedTypes().OrTimeout();
+            var types = await _app.GetCompiledAppDefinedTypes();
             Assert.Equal(2, types);
 
             var fileToChange = Path.Combine(_app.SourceDirectory, "include", "Foo.cs");
             var programCs = File.ReadAllText(fileToChange);
             File.WriteAllText(fileToChange, programCs);
 
-            await _app.HasRestarted().OrTimeout();
-            types = await _app.GetCompiledAppDefinedTypes().OrTimeout();
+            await _app.HasRestarted();
+            types = await _app.GetCompiledAppDefinedTypes();
             Assert.Equal(2, types);
         }
 
         [Fact(Skip = "Broken. See https://github.com/aspnet/DotNetTools/issues/212")]
         public async Task AddCompiledFile()
         {
-            await _app.StartWatcherAsync().OrTimeout();
+            await _app.StartWatcherAsync();
 
-            var types = await _app.GetCompiledAppDefinedTypes().OrTimeout();
+            var types = await _app.GetCompiledAppDefinedTypes();
             Assert.Equal(2, types);
 
             var fileToChange = Path.Combine(_app.SourceDirectory, "include", "Bar.cs");
             File.WriteAllText(fileToChange, "public class Bar {}");
 
-            await _app.HasRestarted().OrTimeout();
-            types = await _app.GetCompiledAppDefinedTypes().OrTimeout();
+            await _app.HasRestarted();
+            types = await _app.GetCompiledAppDefinedTypes();
             Assert.Equal(3, types);
         }
 
         [Fact]
         public async Task DeleteCompiledFile()
         {
-            await _app.StartWatcherAsync().OrTimeout();
+            await _app.StartWatcherAsync();
 
-            var types = await _app.GetCompiledAppDefinedTypes().OrTimeout();
+            var types = await _app.GetCompiledAppDefinedTypes();
             Assert.Equal(2, types);
 
             var fileToChange = Path.Combine(_app.SourceDirectory, "include", "Foo.cs");
             File.Delete(fileToChange);
 
-            await _app.HasRestarted().OrTimeout();
-            types = await _app.GetCompiledAppDefinedTypes().OrTimeout();
+            await _app.HasRestarted();
+            types = await _app.GetCompiledAppDefinedTypes();
             Assert.Equal(1, types);
         }
 
         [Fact]
         public async Task DeleteSourceFolder()
         {
-            await _app.StartWatcherAsync().OrTimeout();
+            await _app.StartWatcherAsync();
 
-            var types = await _app.GetCompiledAppDefinedTypes().OrTimeout();
+            var types = await _app.GetCompiledAppDefinedTypes();
             Assert.Equal(2, types);
 
             var folderToDelete = Path.Combine(_app.SourceDirectory, "include");
             Directory.Delete(folderToDelete, recursive: true);
 
-            await _app.HasRestarted().OrTimeout();
-            types = await _app.GetCompiledAppDefinedTypes().OrTimeout();
+            await _app.HasRestarted();
+            types = await _app.GetCompiledAppDefinedTypes();
             Assert.Equal(1, types);
         }
 
         [Fact]
         public async Task RenameCompiledFile()
         {
-            await _app.StartWatcherAsync().OrTimeout();
+            await _app.StartWatcherAsync();
 
             var oldFile = Path.Combine(_app.SourceDirectory, "include", "Foo.cs");
             var newFile = Path.Combine(_app.SourceDirectory, "include", "Foo_new.cs");
             File.Move(oldFile, newFile);
 
-            await _app.HasRestarted().OrTimeout();
+            await _app.HasRestarted();
         }
 
         [Fact]
         public async Task ChangeExcludedFile()
         {
-            await _app.StartWatcherAsync().OrTimeout();
+            await _app.StartWatcherAsync();
 
             var changedFile = Path.Combine(_app.SourceDirectory, "exclude", "Baz.cs");
             File.WriteAllText(changedFile, "");
@@ -143,7 +143,7 @@ namespace Microsoft.DotNet.Watcher.Tools.FunctionalTests
 
             public async Task<int> GetCompiledAppDefinedTypes()
             {
-                var definedTypesMessage = await Process.GetOutputLineAsync(m => m.StartsWith("Defined types = "));
+                var definedTypesMessage = await Process.GetOutputLineAsync(m => m.StartsWith("Defined types = ")).OrTimeout();
                 return int.Parse(definedTypesMessage.Split('=').Last());
             }
         }

--- a/test/Microsoft.DotNet.Watcher.Tools.FunctionalTests/NoDepsAppTests.cs
+++ b/test/Microsoft.DotNet.Watcher.Tools.FunctionalTests/NoDepsAppTests.cs
@@ -22,16 +22,16 @@ namespace Microsoft.DotNet.Watcher.Tools.FunctionalTests
         [Fact]
         public async Task RestartProcessOnFileChange()
         {
-            await _app.StartWatcherAsync(new[] { "--no-exit" }).OrTimeout();
-            var pid = await _app.GetProcessId().OrTimeout();
+            await _app.StartWatcherAsync(new[] { "--no-exit" });
+            var pid = await _app.GetProcessId();
 
             // Then wait for it to restart when we change a file
             var fileToChange = Path.Combine(_app.SourceDirectory, "Program.cs");
             var programCs = File.ReadAllText(fileToChange);
             File.WriteAllText(fileToChange, programCs);
 
-            await _app.HasRestarted().OrTimeout();
-            var pid2 = await _app.GetProcessId().OrTimeout();
+            await _app.HasRestarted();
+            var pid2 = await _app.GetProcessId();
             Assert.NotEqual(pid, pid2);
 
             // first app should have shut down
@@ -41,18 +41,18 @@ namespace Microsoft.DotNet.Watcher.Tools.FunctionalTests
         [Fact]
         public async Task RestartProcessThatTerminatesAfterFileChange()
         {
-            await _app.StartWatcherAsync().OrTimeout();
-            var pid = await _app.GetProcessId().OrTimeout();
-            await _app.HasExited().OrTimeout(); // process should exit after run
+            await _app.StartWatcherAsync();
+            var pid = await _app.GetProcessId();
+            await _app.HasExited(); // process should exit after run
 
             var fileToChange = Path.Combine(_app.SourceDirectory, "Program.cs");
             var programCs = File.ReadAllText(fileToChange);
             File.WriteAllText(fileToChange, programCs);
 
-            await _app.HasRestarted().OrTimeout();
-            var pid2 = await _app.GetProcessId().OrTimeout();
+            await _app.HasRestarted();
+            var pid2 = await _app.GetProcessId();
             Assert.NotEqual(pid, pid2);
-            await _app.HasExited().OrTimeout(); // process should exit after run
+            await _app.HasExited(); // process should exit after run
         }
 
         public void Dispose()

--- a/test/Microsoft.DotNet.Watcher.Tools.FunctionalTests/Scenario/WatchableApp.cs
+++ b/test/Microsoft.DotNet.Watcher.Tools.FunctionalTests/Scenario/WatchableApp.cs
@@ -38,16 +38,16 @@ namespace Microsoft.DotNet.Watcher.Tools.FunctionalTests
         public string SourceDirectory { get; }
 
         public Task HasRestarted()
-            => Process.GetOutputLineAsync(StartedMessage);
+            => Process.GetOutputLineAsync(StartedMessage).OrTimeout();
 
         public Task HasExited()
-            => Process.GetOutputLineAsync(ExitingMessage);
+            => Process.GetOutputLineAsync(ExitingMessage).OrTimeout();
 
         public bool UsePollingWatcher { get; set; }
 
         public async Task<int> GetProcessId()
         {
-            var line = await Process.GetOutputLineAsync(l => l.StartsWith("PID ="));
+            var line = await Process.GetOutputLineAsync(l => l.StartsWith("PID =")).OrTimeout();
             var pid = line.Split('=').Last();
             return int.Parse(pid);
         }
@@ -93,7 +93,7 @@ namespace Microsoft.DotNet.Watcher.Tools.FunctionalTests
 
             var args = new[] { "run", "--" }.Concat(arguments);
             Start(args, name);
-            await Process.GetOutputLineAsync(StartedMessage);
+            await Process.GetOutputLineAsync(StartedMessage).OrTimeout();
         }
 
         public virtual void Dispose()


### PR DESCRIPTION
Pulled up the calls to .OrTimeout() into the WatchableApp.

The main problem was `.StartWatcherAsync().OrTimeout()`. This applies a 30 second timeout to a piece of the test that calls dotnet-restore. Tests on CI often timeout because of this. The dotnet-restore is already gated by a timeout of 120 seconds, so the `.OrTimeout()` is unnecessary in most places.

Should resolve #336 