### PR TITLE
React to changes in package layout requirements for global CLI tools

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -2,10 +2,8 @@ init:
   - git config --global core.autocrlf true
 branches:
   only:
-    - master
-    - release
-    - /^rel\/.*/
     - dev
+    - /^release\/.*/
     - /^(.*\/)?ci-.*$/
 build_script:
   - ps: .\run.ps1 default-build

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,10 +16,8 @@ addons:
       - libunwind8
 branches:
   only:
-    - master
-    - release
     - dev
-    - /^rel\/.*/
+    - /^release\/.*/
     - /^(.*\/)?ci-.*$/
 before_install:
   - if test "$TRAVIS_OS_NAME" == "osx"; then brew update; brew install openssl; ln -s /usr/local/opt/openssl/lib/libcrypto.1.0.0.dylib /usr/local/lib/; ln -s /usr/local/opt/openssl/lib/libssl.1.0.0.dylib /usr/local/lib/; fi

--- a/NuGetPackageVerifier.json
+++ b/NuGetPackageVerifier.json
@@ -15,18 +15,18 @@
         ],
         "Exclusions": {
           "WRONG_PUBLICKEYTOKEN": {
-            "tools/netcoreapp2.1/any/System.Data.SqlClient.dll": "Assembly is built by another project but bundled in our nupkg.",
-            "tools/netcoreapp2.1/any/System.Text.Encoding.CodePages.dll": "Assembly is built by another project but bundled in our nupkg.",
-            "tools/netcoreapp2.1/any/runtimes/unix/lib/netstandard2.0/System.Data.SqlClient.dll": "Assembly is built by another project but bundled in our nupkg.",
-            "tools/netcoreapp2.1/any/runtimes/win/lib/netcoreapp2.0/System.Text.Encoding.CodePages.dll": "Assembly is built by another project but bundled in our nupkg.",
-            "tools/netcoreapp2.1/any/runtimes/win/lib/netstandard2.0/System.Data.SqlClient.dll": "Assembly is built by another project but bundled in our nupkg."
+            "tools/any/any/System.Data.SqlClient.dll": "Assembly is built by another project but bundled in our nupkg.",
+            "tools/any/any/System.Text.Encoding.CodePages.dll": "Assembly is built by another project but bundled in our nupkg.",
+            "tools/any/any/runtimes/unix/lib/netstandard2.0/System.Data.SqlClient.dll": "Assembly is built by another project but bundled in our nupkg.",
+            "tools/any/any/runtimes/win/lib/netcoreapp2.0/System.Text.Encoding.CodePages.dll": "Assembly is built by another project but bundled in our nupkg.",
+            "tools/any/any/runtimes/win/lib/netstandard2.0/System.Data.SqlClient.dll": "Assembly is built by another project but bundled in our nupkg."
           },
           "ASSEMBLY_INFORMATIONAL_VERSION_MISMATCH": {
-            "tools/netcoreapp2.1/any/System.Data.SqlClient.dll": "Assembly is built by another project but bundled in our nupkg.",
-            "tools/netcoreapp2.1/any/System.Text.Encoding.CodePages.dll": "Assembly is built by another project but bundled in our nupkg.",
-            "tools/netcoreapp2.1/any/runtimes/unix/lib/netstandard2.0/System.Data.SqlClient.dll": "Assembly is built by another project but bundled in our nupkg.",
-            "tools/netcoreapp2.1/any/runtimes/win/lib/netcoreapp2.0/System.Text.Encoding.CodePages.dll": "Assembly is built by another project but bundled in our nupkg.",
-            "tools/netcoreapp2.1/any/runtimes/win/lib/netstandard2.0/System.Data.SqlClient.dll": "Assembly is built by another project but bundled in our nupkg."
+            "tools/any/any/System.Data.SqlClient.dll": "Assembly is built by another project but bundled in our nupkg.",
+            "tools/any/any/System.Text.Encoding.CodePages.dll": "Assembly is built by another project but bundled in our nupkg.",
+            "tools/any/any/runtimes/unix/lib/netstandard2.0/System.Data.SqlClient.dll": "Assembly is built by another project but bundled in our nupkg.",
+            "tools/any/any/runtimes/win/lib/netcoreapp2.0/System.Text.Encoding.CodePages.dll": "Assembly is built by another project but bundled in our nupkg.",
+            "tools/any/any/runtimes/win/lib/netstandard2.0/System.Data.SqlClient.dll": "Assembly is built by another project but bundled in our nupkg."
           }
         }
       },
@@ -36,28 +36,28 @@
         ],
         "Exclusions": {
           "NEUTRAL_RESOURCES_LANGUAGE": {
-            "tools/netcoreapp2.1/any/Newtonsoft.Json.dll": "Assembly is built by another project but bundled in our nupkg.",
-            "tools/netcoreapp2.1/any/System.Runtime.CompilerServices.Unsafe.dll": "Assembly is built by another project but bundled in our nupkg."
+            "tools/any/any/Newtonsoft.Json.dll": "Assembly is built by another project but bundled in our nupkg.",
+            "tools/any/any/System.Runtime.CompilerServices.Unsafe.dll": "Assembly is built by another project but bundled in our nupkg."
           },
           "SERVICING_ATTRIBUTE": {
-            "tools/netcoreapp2.1/any/Newtonsoft.Json.dll": "Assembly is built by another project but bundled in our nupkg."
+            "tools/any/any/Newtonsoft.Json.dll": "Assembly is built by another project but bundled in our nupkg."
           },
           "VERSION_INFORMATIONALVERSION": {
-            "tools/netcoreapp2.1/any/Newtonsoft.Json.dll": "Assembly is built by another project but bundled in our nupkg."
+            "tools/any/any/Newtonsoft.Json.dll": "Assembly is built by another project but bundled in our nupkg."
           },
           "WRONG_PUBLICKEYTOKEN": {
-            "tools/netcoreapp2.1/any/Newtonsoft.Json.dll": "Assembly is built by another project but bundled in our nupkg.",
-            "tools/netcoreapp2.1/any/System.Runtime.CompilerServices.Unsafe.dll": "Assembly is built by another project but bundled in our nupkg."
+            "tools/any/any/Newtonsoft.Json.dll": "Assembly is built by another project but bundled in our nupkg.",
+            "tools/any/any/System.Runtime.CompilerServices.Unsafe.dll": "Assembly is built by another project but bundled in our nupkg."
           },
           "ASSEMBLY_INFORMATIONAL_VERSION_MISMATCH": {
-            "tools/netcoreapp2.1/any/Newtonsoft.Json.dll": "Assembly is built by another project but bundled in our nupkg.",
-            "tools/netcoreapp2.1/any/System.Runtime.CompilerServices.Unsafe.dll": "Assembly is built by another project but bundled in our nupkg."
+            "tools/any/any/Newtonsoft.Json.dll": "Assembly is built by another project but bundled in our nupkg.",
+            "tools/any/any/System.Runtime.CompilerServices.Unsafe.dll": "Assembly is built by another project but bundled in our nupkg."
           },
           "ASSEMBLY_FILE_VERSION_MISMATCH": {
-            "tools/netcoreapp2.1/any/System.Runtime.CompilerServices.Unsafe.dll": "Assembly is built by another project but bundled in our nupkg."
+            "tools/any/any/System.Runtime.CompilerServices.Unsafe.dll": "Assembly is built by another project but bundled in our nupkg."
           },
           "ASSEMBLY_VERSION_MISMATCH": {
-            "tools/netcoreapp2.1/any/System.Runtime.CompilerServices.Unsafe.dll": "Assembly is built by another project but bundled in our nupkg."
+            "tools/any/any/System.Runtime.CompilerServices.Unsafe.dll": "Assembly is built by another project but bundled in our nupkg."
           }
         }
       },

--- a/README.md
+++ b/README.md
@@ -23,10 +23,10 @@ For stable, released versions of the tools, see [these instructions](https://git
 Install tools using the .NET Core command-line.
 
 ```
-dotnet install tool dotnet-watch
-dotnet install tool dotnet-user-secrets
-dotnet install tool dotnet-dev-certs
-dotnet install tool dotnet-sql-cache
+dotnet install tool --global dotnet-watch
+dotnet install tool --global dotnet-user-secrets
+dotnet install tool --global dotnet-dev-certs
+dotnet install tool --global dotnet-sql-cache
 ```
 
 ## Usage

--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -3,7 +3,7 @@
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
   </PropertyGroup>
   <PropertyGroup Label="Package Versions">
-    <InternalAspNetCoreSdkPackageVersion>2.1.0-preview1-15679</InternalAspNetCoreSdkPackageVersion>
+    <InternalAspNetCoreSdkPackageVersion>2.1.0-preview1-15681</InternalAspNetCoreSdkPackageVersion>
     <MicrosoftAspNetCoreCertificatesGenerationSourcesPackageVersion>2.1.0-preview1-28153</MicrosoftAspNetCoreCertificatesGenerationSourcesPackageVersion>
     <MicrosoftAspNetCoreTestingPackageVersion>2.1.0-preview1-28153</MicrosoftAspNetCoreTestingPackageVersion>
     <MicrosoftExtensionsCommandLineUtilsSourcesPackageVersion>2.1.0-preview1-28153</MicrosoftExtensionsCommandLineUtilsSourcesPackageVersion>

--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -11,6 +11,7 @@
     <MicrosoftExtensionsProcessSourcesPackageVersion>2.1.0-preview1-28153</MicrosoftExtensionsProcessSourcesPackageVersion>
     <MicrosoftNETCoreApp20PackageVersion>2.0.0</MicrosoftNETCoreApp20PackageVersion>
     <MicrosoftNETCoreApp21PackageVersion>2.1.0-preview1-26115-03</MicrosoftNETCoreApp21PackageVersion>
+    <MicrosoftNETCorePlatformsPackageVersion>2.1.0-preview1-26112-01</MicrosoftNETCorePlatformsPackageVersion>
     <MicrosoftNETTestSdkPackageVersion>15.3.0</MicrosoftNETTestSdkPackageVersion>
     <SystemDataSqlClientPackageVersion>4.5.0-preview1-26112-01</SystemDataSqlClientPackageVersion>
     <SystemSecurityCryptographyCngPackageVersion>4.5.0-preview1-26112-01</SystemSecurityCryptographyCngPackageVersion>

--- a/korebuild-lock.txt
+++ b/korebuild-lock.txt
@@ -1,2 +1,2 @@
-version:2.1.0-preview1-15679
-commithash:5347461137cb45a77ddcc0b55b2478092de43338
+version:2.1.0-preview1-15681
+commithash:409cab8f55191829e70f2f8e307196fd6a427b4c

--- a/src/DotnetTool.props
+++ b/src/DotnetTool.props
@@ -11,6 +11,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <SignedPackageFile Include="$(TargetPath)" PackagePath="tools/$(TargetFramework)/any/$(TargetFileName)" Certificate="$(AssemblySigningCertName)" />
+    <SignedPackageFile Include="$(TargetPath)" PackagePath="tools/any/any/$(TargetFileName)" Certificate="$(AssemblySigningCertName)" />
   </ItemGroup>
 </Project>

--- a/src/PackGlobalTool.targets
+++ b/src/PackGlobalTool.targets
@@ -12,6 +12,7 @@
         description=$(Description);
         repositoryUrl=$(RepositoryUrl);
         targetframework=$(TargetFramework);
+        MicrosoftNETCorePlatformsPackageVersion=$(MicrosoftNETCorePlatformsPackageVersion);
       </NuspecProperties>
     </PropertyGroup>
   </Target>

--- a/src/dotnet-dev-certs/README.md
+++ b/src/dotnet-dev-certs/README.md
@@ -1,0 +1,16 @@
+dotnet-dev-certs
+================
+
+`dotnet-dev-certs` is a command line tool to generate certificates used in ASP.NET Core during development.
+
+### How To Install
+
+From the command-line, execute:
+
+```
+dotnet install tool --global dotnet-dev-certs
+```
+
+### How To Use
+
+Run `dotnet dev-certs --help` for more information about usage.

--- a/src/dotnet-dev-certs/dotnet-dev-certs.nuspec
+++ b/src/dotnet-dev-certs/dotnet-dev-certs.nuspec
@@ -17,10 +17,13 @@
       <packageType name="DotnetTool" />
     </packageTypes>
     <repository type="git" url="$repositoryUrl$" />
-    <dependencies />
+    <dependencies>
+      <!-- Workaround https://github.com/dotnet/cli/issues/8418 -->
+      <dependency id="Microsoft.NETCore.Platforms" version="$MicrosoftNETCorePlatformsPackageVersion$" />
+    </dependencies>
   </metadata>
   <files>
-    <file src="$publishdir$" target="tools/$targetframework$/any/" />
-    <file src="DotnetToolSettings.xml" target="tools/DotnetToolSettings.xml" />
+    <file src="$publishdir$" target="tools/any/any/" />
+    <file src="DotnetToolSettings.xml" target="tools/any/any/DotnetToolSettings.xml" />
   </files>
 </package>

--- a/src/dotnet-sql-cache/README.md
+++ b/src/dotnet-sql-cache/README.md
@@ -8,7 +8,7 @@ dotnet-sql-cache
 From the command-line, execute:
 
 ```
-dotnet install tool dotnet-sql-cache
+dotnet install tool --global dotnet-sql-cache
 ```
 
 ### How To Use

--- a/src/dotnet-sql-cache/dotnet-sql-cache.csproj
+++ b/src/dotnet-sql-cache/dotnet-sql-cache.csproj
@@ -5,7 +5,7 @@
     <OutputType>exe</OutputType>
     <Description>Command line tool to create tables and indexes in a Microsoft SQL Server database for distributed caching.</Description>
     <PackageType>DotnetTool</PackageType>
-    <PackageBasePath>tools/$(TargetFramework)/any/</PackageBasePath>
+    <PackageBasePath>tools/any/any/</PackageBasePath>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/dotnet-sql-cache/dotnet-sql-cache.nuspec
+++ b/src/dotnet-sql-cache/dotnet-sql-cache.nuspec
@@ -17,10 +17,13 @@
       <packageType name="DotnetTool" />
     </packageTypes>
     <repository type="git" url="$repositoryUrl$" />
-    <dependencies />
+    <dependencies>
+      <!-- Workaround https://github.com/dotnet/cli/issues/8418 -->
+      <dependency id="Microsoft.NETCore.Platforms" version="$MicrosoftNETCorePlatformsPackageVersion$" />
+    </dependencies>
   </metadata>
   <files>
-    <file src="$publishdir$" target="tools/$targetframework$/any/" />
-    <file src="DotnetToolSettings.xml" target="tools/DotnetToolSettings.xml" />
+    <file src="$publishdir$" target="tools/any/any/" />
+    <file src="DotnetToolSettings.xml" target="tools/any/any/DotnetToolSettings.xml" />
   </files>
 </package>

--- a/src/dotnet-user-secrets/README.md
+++ b/src/dotnet-user-secrets/README.md
@@ -8,7 +8,7 @@ dotnet-user-secrets
 From the command-line, execute:
 
 ```
-dotnet install tool dotnet-user-secrets
+dotnet install tool --global dotnet-user-secrets
 ```
 
 ### How To Use

--- a/src/dotnet-user-secrets/dotnet-user-secrets.csproj
+++ b/src/dotnet-user-secrets/dotnet-user-secrets.csproj
@@ -7,7 +7,7 @@
     <PackageType>DotnetTool</PackageType>
     <GenerateUserSecretsAttribute>false</GenerateUserSecretsAttribute>
     <RootNamespace>Microsoft.Extensions.SecretManager.Tools</RootNamespace>
-    <PackageBasePath>tools/$(TargetFramework)/any/</PackageBasePath>
+    <PackageBasePath>tools/any/any/</PackageBasePath>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/dotnet-user-secrets/dotnet-user-secrets.nuspec
+++ b/src/dotnet-user-secrets/dotnet-user-secrets.nuspec
@@ -17,10 +17,13 @@
       <packageType name="DotnetTool" />
     </packageTypes>
     <repository type="git" url="$repositoryUrl$" />
-    <dependencies />
+    <dependencies>
+      <!-- Workaround https://github.com/dotnet/cli/issues/8418 -->
+      <dependency id="Microsoft.NETCore.Platforms" version="$MicrosoftNETCorePlatformsPackageVersion$" />
+    </dependencies>
   </metadata>
   <files>
-    <file src="$publishdir$" target="tools/$targetframework$/any/" />
-    <file src="DotnetToolSettings.xml" target="tools/DotnetToolSettings.xml" />
+    <file src="$publishdir$" target="tools/any/any/" />
+    <file src="DotnetToolSettings.xml" target="tools/any/any/DotnetToolSettings.xml" />
   </files>
 </package>

--- a/src/dotnet-watch/README.md
+++ b/src/dotnet-watch/README.md
@@ -7,7 +7,7 @@ dotnet-watch
 From the command-line, execute:
 
 ```
-dotnet install tool dotnet-watch
+dotnet install tool --global dotnet-watch
 ```
 
 ### How To Use

--- a/src/dotnet-watch/dotnet-watch.nuspec
+++ b/src/dotnet-watch/dotnet-watch.nuspec
@@ -17,10 +17,13 @@
       <packageType name="DotnetTool" />
     </packageTypes>
     <repository type="git" url="$repositoryUrl$" />
-    <dependencies />
+    <dependencies>
+      <!-- Workaround https://github.com/dotnet/cli/issues/8418 -->
+      <dependency id="Microsoft.NETCore.Platforms" version="$MicrosoftNETCorePlatformsPackageVersion$" />
+    </dependencies>
   </metadata>
   <files>
-    <file src="$publishdir$" target="tools/$targetframework$/any/" />
-    <file src="DotnetToolSettings.xml" target="tools/DotnetToolSettings.xml" />
+    <file src="$publishdir$" target="tools/any/any/" />
+    <file src="DotnetToolSettings.xml" target="tools/any/any/DotnetToolSettings.xml" />
   </files>
 </package>


### PR DESCRIPTION
React to  dotnet/cli#8414 which causes latest dotnet-watch packages not to install via dotnet-install-tool.

Depends on https://github.com/aspnet/BuildTools/pull/558

Resolves https://github.com/aspnet/DotNetTools/issues/383

