### PR TITLE
Include symbols in build output for the VSIX project, and update vsix manifest dependency version

### DIFF
--- a/build/VSIX.targets
+++ b/build/VSIX.targets
@@ -8,6 +8,7 @@
     <VSIXProject>$(RepositoryRoot)tooling\$(VSIXName)\$(VSIXName).csproj</VSIXProject>
     <VSIXOutputPath>$(BuildDir)$(VSIXName).vsix</VSIXOutputPath>
     <VSIXManifestOutputPath>$(BuildDir)$(VSIXName).json</VSIXManifestOutputPath>
+    <VSIXSymbolsOutputPath>$(BuildDir)$(VSIXName).pdb</VSIXSymbolsOutputPath>
     <VSIXArtifactCategory>shipoob</VSIXArtifactCategory>
   </PropertyGroup>
 
@@ -32,8 +33,16 @@
         <PackageId>$(VSIXName)</PackageId>
       </ArtifactInfo>
 
+      <ArtifactInfo Include="$(VSIXSymbolsOutputPath)">
+        <ArtifactType>SymbolsFile</ArtifactType>
+        <Category>$(VSIXArtifactCategory)</Category>
+        <Dependencies>$(VSIXName).vsix</Dependencies>
+        <DebugType>full</DebugType>
+      </ArtifactInfo>
+
       <FilesToSign Include="$(VSIXOutputPath)" Certificate="Vsix" IsContainer="true" />
       <FilesToExcludeFromSigning Include="$(VSIXManifestOutputPath)" />
+      <FilesToExcludeFromSigning Include="$(VSIXSymbolsOutputPath)" />
     </ItemGroup>
   </Target>
 
@@ -92,6 +101,7 @@
         /p:DeployExtension=false;
         /p:TargetVSIXContainer=$(VSIXOutputPath);
         /p:Configuration=$(Configuration);
+        /p:SymbolsPublishDir=$(BuildDir);
         /p:PackageReferencePropsPath=$(MSBuildThisFileDirectory)VSIX.props;" />
     </ItemGroup>
 

--- a/tooling/Microsoft.VisualStudio.SecretManager/Microsoft.VisualStudio.SecretManager.csproj
+++ b/tooling/Microsoft.VisualStudio.SecretManager/Microsoft.VisualStudio.SecretManager.csproj
@@ -37,7 +37,7 @@
     <IncludeDebugSymbolsInVSIXContainer>false</IncludeDebugSymbolsInVSIXContainer>
     <IncludeDebugSymbolsInLocalVSIXDeployment>true</IncludeDebugSymbolsInLocalVSIXDeployment>
     <CopyBuildOutputToOutputDirectory>true</CopyBuildOutputToOutputDirectory>
-    <CopyOutputSymbolsToOutputDirectory>false</CopyOutputSymbolsToOutputDirectory>
+    <CopyOutputSymbolsToOutputDirectory>true</CopyOutputSymbolsToOutputDirectory>
     <StartAction>Program</StartAction>
     <StartProgram Condition="'$(DevEnvDir)' != ''">$(DevEnvDir)devenv.exe</StartProgram>
     <StartArguments>/rootsuffix Exp</StartArguments>
@@ -53,7 +53,8 @@
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
@@ -109,4 +110,8 @@
   <Target Name="GetBuildVersion" Outputs="$(VsixVersion)" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets" Condition="'$(VSToolsPath)' != ''" />
+
+  <Target Name="CopySymbolsToOutput" AfterTargets="Build" Condition="'$(SymbolsPublishDir)' != ''">
+    <Copy SourceFiles="$(OutDir)$(AssemblyName).pdb" DestinationFolder="$(SymbolsPublishDir)" />
+  </Target>
 </Project>

--- a/tooling/Microsoft.VisualStudio.SecretManager/source.extension.vsixmanifest
+++ b/tooling/Microsoft.VisualStudio.SecretManager/source.extension.vsixmanifest
@@ -14,7 +14,7 @@
         <Dependency Id="Microsoft.VisualStudio.MPF.15.0" DisplayName="Visual Studio MPF 15.0" d:Source="Installed" Version="[15.0]" />
     </Dependencies>
     <Prerequisites>
-        <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0)" DisplayName="Visual Studio core editor" />
+        <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,16.0)" DisplayName="Visual Studio core editor" />
     </Prerequisites>
     <Assets>
         <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%|" />


### PR DESCRIPTION
cc @NTaylorMullen @rynowak  - we should make the same change for Microsoft.VisualStudio.RazorExtension.pdb. Apparently, its not supposed to be in the VSIX itself.