### PR TITLE
Add more logging for flaky tests on CI

### DIFF
--- a/test/dotnet-watch.FunctionalTests/AwaitableProcess.cs
+++ b/test/dotnet-watch.FunctionalTests/AwaitableProcess.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading.Tasks;
 using System.Threading.Tasks.Dataflow;
+using Microsoft.AspNetCore.Testing;
 using Microsoft.Extensions.Internal;
 using Microsoft.Extensions.CommandLineUtils;
 using Xunit.Abstractions;
@@ -61,10 +62,19 @@ namespace Microsoft.DotNet.Watcher.Tools.FunctionalTests
             _logger.WriteLine($"{DateTime.Now}: process start: '{_process.StartInfo.FileName} {_process.StartInfo.Arguments}'");
         }
 
-        public Task<string> GetOutputLineAsync(string message)
-            => GetOutputLineAsync(m => message == m);
+        public async Task<string> GetOutputLineAsync(string message, TimeSpan timeout)
+        {
+            _logger.WriteLine($"Waiting for output line [msg == '{message}']. Will wait for {timeout.TotalSeconds} sec.");
+            return await GetOutputLineAsync(m => message == m).TimeoutAfter(timeout);
+        }
 
-        public async Task<string> GetOutputLineAsync(Predicate<string> predicate)
+        public async Task<string> GetOutputLineStartsWithAsync(string message, TimeSpan timeout)
+        {
+            _logger.WriteLine($"Waiting for output line [msg.StartsWith('{message}')]. Will wait for {timeout.TotalSeconds} sec.");
+            return await GetOutputLineAsync(m => m.StartsWith(message)).TimeoutAfter(timeout);
+        }
+
+        private async Task<string> GetOutputLineAsync(Predicate<string> predicate)
         {
             while (!_source.Completion.IsCompleted)
             {

--- a/test/dotnet-watch.FunctionalTests/DotNetWatcherTests.cs
+++ b/test/dotnet-watch.FunctionalTests/DotNetWatcherTests.cs
@@ -25,7 +25,7 @@ namespace Microsoft.DotNet.Watcher.Tools.FunctionalTests
 
             await _app.StartWatcherAsync();
             const string messagePrefix = "DOTNET_WATCH = ";
-            var message = await _app.Process.GetOutputLineAsync(m => m.StartsWith(messagePrefix));
+            var message = await _app.Process.GetOutputLineStartsWithAsync(messagePrefix, TimeSpan.FromMinutes(2));
             var envValue = message.Substring(messagePrefix.Length);
             Assert.Equal("1", envValue);
         }

--- a/test/dotnet-watch.FunctionalTests/GlobbingAppTests.cs
+++ b/test/dotnet-watch.FunctionalTests/GlobbingAppTests.cs
@@ -5,7 +5,6 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Testing;
 using Microsoft.DotNet.Watcher.Tools.Tests;
 using Xunit;
 using Xunit.Abstractions;
@@ -129,7 +128,7 @@ namespace Microsoft.DotNet.Watcher.Tools.FunctionalTests
 
             public async Task<int> GetCompiledAppDefinedTypes()
             {
-                var definedTypesMessage = await Process.GetOutputLineAsync(m => m.StartsWith("Defined types = ")).TimeoutAfter(TimeSpan.FromSeconds(30));
+                var definedTypesMessage = await Process.GetOutputLineStartsWithAsync("Defined types = ", TimeSpan.FromSeconds(30));
                 return int.Parse(definedTypesMessage.Split('=').Last());
             }
         }

--- a/test/dotnet-watch.FunctionalTests/Scenario/WatchableApp.cs
+++ b/test/dotnet-watch.FunctionalTests/Scenario/WatchableApp.cs
@@ -7,7 +7,6 @@ using System.IO;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Testing;
 using Microsoft.Extensions.CommandLineUtils;
 using Xunit.Abstractions;
 
@@ -41,16 +40,16 @@ namespace Microsoft.DotNet.Watcher.Tools.FunctionalTests
         public string SourceDirectory { get; }
 
         public Task HasRestarted()
-            => Process.GetOutputLineAsync(StartedMessage).TimeoutAfter(DefaultMessageTimeOut);
+            => Process.GetOutputLineAsync(StartedMessage, DefaultMessageTimeOut);
 
         public Task HasExited()
-            => Process.GetOutputLineAsync(ExitingMessage).TimeoutAfter(DefaultMessageTimeOut);
+            => Process.GetOutputLineAsync(ExitingMessage, DefaultMessageTimeOut);
 
         public bool UsePollingWatcher { get; set; }
 
         public async Task<int> GetProcessId()
         {
-            var line = await Process.GetOutputLineAsync(l => l.StartsWith("PID =")).TimeoutAfter(DefaultMessageTimeOut);
+            var line = await Process.GetOutputLineStartsWithAsync("PID =", DefaultMessageTimeOut);
             var pid = line.Split('=').Last();
             return int.Parse(pid);
         }
@@ -106,7 +105,7 @@ namespace Microsoft.DotNet.Watcher.Tools.FunctionalTests
 
             // Make this timeout long because it depends much on the MSBuild compilation speed.
             // Slow machines may take a bit to compile and boot test apps
-            await Process.GetOutputLineAsync(StartedMessage).TimeoutAfter(TimeSpan.FromMinutes(2));
+            await Process.GetOutputLineAsync(StartedMessage, TimeSpan.FromMinutes(2));
         }
 
         public virtual void Dispose()


### PR DESCRIPTION
Closes https://github.com/aspnet/DotNetTools/issues/336

I ran this test in a loop 100 times on Travis, Appveyor, and locally, and didn't get a repro of https://github.com/aspnet/DotNetTools/issues/336 anymore.

https://ci.appveyor.com/project/aspnetci/dotnettools/build/1.0.293
https://travis-ci.org/aspnet/DotNetTools/builds/340622426

Adds better logging for potential flaky tests in dotnet-watch. 