### PR TITLE
Remove hyphen from the dev-certs tool name

### DIFF
--- a/src/dotnet-dev-certs/Program.cs
+++ b/src/dotnet-dev-certs/Program.cs
@@ -33,7 +33,7 @@ namespace Microsoft.AspNetCore.DeveloperCertificates.Tools
             {
                 var app = new CommandLineApplication
                 {
-                    Name = "dotnet-dev-certs"
+                    Name = "dotnet dev-certs"
                 };
 
                 app.Command("https", c =>


### PR DESCRIPTION
Fixes https://github.com/aspnet/DotNetTools/issues/384