### PR TITLE
Update README to reflect that dotnet-watch et. al. are bundled in the CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,30 +8,18 @@ This project is part of ASP.NET Core. You can find samples, documentation and ge
 
 ## Projects
 
-The repository contains command-line tools for the .NET Core CLI. Follow the links below for more details on each tool.
+The repository contains command-line tools for ASP.NET Core that are bundled* in the .NET Core CLI. Follow the links below for more details on each tool.
 
- - [dotnet-watch](src/dotnet-watch/)
- - [dotnet-user-secrets](src/dotnet-user-secrets/)
- - [dotnet-sql-cache](src/dotnet-sql-cache/) (dotnet-sql-cache)
- - [dotnet-dev-certs](src/dotnet-dev-certs/) (dotnet-dev-certs)
+ - [dotnet-watch](src/dotnet-watch/README.md)
+ - [dotnet-user-secrets](src/dotnet-user-secrets/README.md)
+ - [dotnet-sql-cache](src/dotnet-sql-cache/README.md)
+ - [dotnet-dev-certs](src/dotnet-dev-certs/README.md)
 
-## How to Install
-
-:warning: These instructions currently require a prerelease version of the [.NET Core SDK](https://github.com/dotnet/cli).
-For stable, released versions of the tools, see [these instructions](https://github.com/aspnet/DotNetTools/tree/release/2.0#how-to-install).
-
-Install tools using the .NET Core command-line.
-
-```
-dotnet install tool --global dotnet-watch
-dotnet install tool --global dotnet-user-secrets
-dotnet install tool --global dotnet-dev-certs
-dotnet install tool --global dotnet-sql-cache
-```
+*\*This applies to .NET Core CLI 2.1.300 and up. For earlier versions of the CLI, these tools must be installed separately. See the [release/2.0](https://github.com/aspnet/DotNetTools/tree/release/2.0/README.md) branch for details.*
 
 ## Usage
 
-The command line tools can be invoked as a new verb hanging off `dotnet`.
+The command line tools can be invoked as a subcommand of `dotnet`.
 
 ```sh
 dotnet watch

--- a/korebuild-lock.txt
+++ b/korebuild-lock.txt
@@ -1,2 +1,2 @@
-version:2.1.0-preview2-15707
-commithash:e74e53f129ab34332947fea7ac7b7591b027cb22
+version:2.1.0-preview2-15711
+commithash:da1ea560df398a50ef9a39a459c24dc36f9c87d9

--- a/src/dotnet-dev-certs/README.md
+++ b/src/dotnet-dev-certs/README.md
@@ -3,14 +3,6 @@ dotnet-dev-certs
 
 `dotnet-dev-certs` is a command line tool to generate certificates used in ASP.NET Core during development.
 
-### How To Install
-
-From the command-line, execute:
-
-```
-dotnet install tool --global dotnet-dev-certs
-```
-
 ### How To Use
 
 Run `dotnet dev-certs --help` for more information about usage.

--- a/src/dotnet-sql-cache/README.md
+++ b/src/dotnet-sql-cache/README.md
@@ -3,14 +3,6 @@ dotnet-sql-cache
 
 `dotnet-sql-cache` is a command line tool that creates table and indexes in Microsoft SQL Server database to be used for distributed caching
 
-### How To Install
-
-From the command-line, execute:
-
-```
-dotnet install tool --global dotnet-sql-cache
-```
-
 ### How To Use
 
 Run `dotnet sql-cache --help` for more information about usage.

--- a/src/dotnet-user-secrets/README.md
+++ b/src/dotnet-user-secrets/README.md
@@ -3,14 +3,6 @@ dotnet-user-secrets
 
 `dotnet-user-secrets` is a command line tool for managing the secrets in a user secret store.
 
-### How To Install
-
-From the command-line, execute:
-
-```
-dotnet install tool --global dotnet-user-secrets
-```
-
 ### How To Use
 
 Run `dotnet user-secrets --help` for more information about usage.

--- a/src/dotnet-watch/README.md
+++ b/src/dotnet-watch/README.md
@@ -2,14 +2,6 @@ dotnet-watch
 ============
 `dotnet-watch` is a file watcher for `dotnet` that restarts the specified application when changes in the source code are detected.
 
-### How To Install
-
-From the command-line, execute:
-
-```
-dotnet install tool --global dotnet-watch
-```
-
 ### How To Use
 
 The command must be executed in the directory that contains the project to be watched.


### PR DESCRIPTION
Part of https://github.com/aspnet/DotNetTools/issues/396

cref https://github.com/dotnet/cli/pull/8665