### PR TITLE
Disable node reuse from dotnet-watch and dotnet-user-secrets

### DIFF
--- a/src/dotnet-user-secrets/Internal/ProjectIdResolver.cs
+++ b/src/dotnet-user-secrets/Internal/ProjectIdResolver.cs
@@ -55,7 +55,11 @@ namespace Microsoft.Extensions.SecretManager.Tools.Internal
                     FileName = DotNetMuxer.MuxerPathOrDefault(),
                     Arguments = ArgumentEscaper.EscapeAndConcatenate(args),
                     RedirectStandardOutput = true,
-                    RedirectStandardError = true
+                    RedirectStandardError = true,
+                    Environment =
+                    {
+                        ["MSBUILDDISABLENODEREUSE"] = "1",
+                    }
                 };
 
 #if DEBUG

--- a/src/dotnet-watch/Internal/MsBuildFileSetFactory.cs
+++ b/src/dotnet-watch/Internal/MsBuildFileSetFactory.cs
@@ -75,7 +75,11 @@ namespace Microsoft.DotNet.Watcher.Internal
                             _projectFile,
                             $"/p:_DotNetWatchListFile={watchList}"
                         }.Concat(_buildFlags),
-                        OutputCapture = capture
+                        OutputCapture = capture,
+                        EnvironmentVariables =
+                        {
+                            ["MSBUILDDISABLENODEREUSE"] = "1",
+                        }
                     };
 
                     _reporter.Verbose($"Running MSBuild target '{TargetName}' on '{_projectFile}'");

--- a/test/dotnet-watch.FunctionalTests/AwaitableProcess.cs
+++ b/test/dotnet-watch.FunctionalTests/AwaitableProcess.cs
@@ -47,7 +47,8 @@ namespace Microsoft.DotNet.Watcher.Tools.FunctionalTests
                     RedirectStandardError = true,
                     Environment =
                     {
-                        ["DOTNET_SKIP_FIRST_TIME_EXPERIENCE"] = "true"
+                        ["DOTNET_SKIP_FIRST_TIME_EXPERIENCE"] = "true",
+                        ["MSBUILDDISABLENODEREUSE"] = "1",
                     }
                 }
             };


### PR DESCRIPTION
At the moment, this is a guess. I suspect the flakiness may be due to the addition of node reuse to dotnet msbuild.