### PR TITLE
Fix race condition in test code waiting for dotnet-watch to restart

### DIFF
--- a/test/dotnet-watch.FunctionalTests/AwaitableProcess.cs
+++ b/test/dotnet-watch.FunctionalTests/AwaitableProcess.cs
@@ -116,6 +116,8 @@ namespace Microsoft.DotNet.Watcher.Tools.FunctionalTests
 
         private void OnExit(object sender, EventArgs args)
         {
+            // Wait to ensure the process has exited and all output consumed
+            _process.WaitForExit();
             _source.Complete();
         }
 

--- a/test/dotnet-watch.FunctionalTests/NoDepsAppTests.cs
+++ b/test/dotnet-watch.FunctionalTests/NoDepsAppTests.cs
@@ -41,7 +41,7 @@ namespace Microsoft.DotNet.Watcher.Tools.FunctionalTests
             Assert.Throws<ArgumentException>(() => Process.GetProcessById(pid));
         }
 
-        [Fact(Skip="https://github.com/aspnet/DotNetTools/issues/407")]
+        [Fact]
         public async Task RestartProcessThatTerminatesAfterFileChange()
         {
             await _app.StartWatcherAsync();

--- a/test/dotnet-watch.FunctionalTests/Scenario/WatchableApp.cs
+++ b/test/dotnet-watch.FunctionalTests/Scenario/WatchableApp.cs
@@ -18,6 +18,7 @@ namespace Microsoft.DotNet.Watcher.Tools.FunctionalTests
 
         private const string StartedMessage = "Started";
         private const string ExitingMessage = "Exiting";
+        private const string WatchExitedMessage = "watch : Exited";
 
         private readonly ITestOutputHelper _logger;
         private string _appName;
@@ -42,8 +43,11 @@ namespace Microsoft.DotNet.Watcher.Tools.FunctionalTests
         public Task HasRestarted()
             => Process.GetOutputLineAsync(StartedMessage, DefaultMessageTimeOut);
 
-        public Task HasExited()
-            => Process.GetOutputLineAsync(ExitingMessage, DefaultMessageTimeOut);
+        public async Task HasExited()
+        {
+            await Process.GetOutputLineAsync(ExitingMessage, DefaultMessageTimeOut);
+            await Process.GetOutputLineAsync(WatchExitedMessage, DefaultMessageTimeOut);
+        }
 
         public bool UsePollingWatcher { get; set; }
 


### PR DESCRIPTION
Resolves https://github.com/aspnet/DotNetTools/issues/407.

Two possible causes of race conditions that these changes should address
1. the .Exited event on Process is raised before all output has been processed
2. the RestartProcessThatTerminatesAfterFileChange test triggers a file change after the inner test app has exited but before dotnet-watch has detected this exit

cc @Eilon @muratg - targeting this change for preview2, addresses a flaky test