### PR TITLE
Ensure restore settings and package versions flow into test projects during CI builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,11 +29,9 @@ project.lock.json
 .build/
 /.vs/
 .vscode/
-testWorkDir/
 *.nuget.props
 *.nuget.targets
 .idea/
 .dotnet/
 global.json
 *.binlog
-test/dotnet-watch.FunctionalTests/TestProjects/NuGet.config

--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -4,16 +4,16 @@
   </PropertyGroup>
   <PropertyGroup Label="Package Versions">
     <InternalAspNetCoreSdkPackageVersion>2.1.0-preview2-15749</InternalAspNetCoreSdkPackageVersion>
-    <MicrosoftAspNetCoreCertificatesGenerationSourcesPackageVersion>2.1.0-preview2-30478</MicrosoftAspNetCoreCertificatesGenerationSourcesPackageVersion>
-    <MicrosoftAspNetCoreTestingPackageVersion>2.1.0-preview2-30478</MicrosoftAspNetCoreTestingPackageVersion>
-    <MicrosoftExtensionsCommandLineUtilsSourcesPackageVersion>2.1.0-preview2-30478</MicrosoftExtensionsCommandLineUtilsSourcesPackageVersion>
-    <MicrosoftExtensionsConfigurationUserSecretsPackageVersion>2.1.0-preview2-30478</MicrosoftExtensionsConfigurationUserSecretsPackageVersion>
-    <MicrosoftExtensionsProcessSourcesPackageVersion>2.1.0-preview2-30478</MicrosoftExtensionsProcessSourcesPackageVersion>
+    <MicrosoftAspNetCoreCertificatesGenerationSourcesPackageVersion>2.1.0-preview2-30559</MicrosoftAspNetCoreCertificatesGenerationSourcesPackageVersion>
+    <MicrosoftAspNetCoreTestingPackageVersion>2.1.0-preview2-30559</MicrosoftAspNetCoreTestingPackageVersion>
+    <MicrosoftExtensionsCommandLineUtilsSourcesPackageVersion>2.1.0-preview2-30559</MicrosoftExtensionsCommandLineUtilsSourcesPackageVersion>
+    <MicrosoftExtensionsConfigurationUserSecretsPackageVersion>2.1.0-preview2-30559</MicrosoftExtensionsConfigurationUserSecretsPackageVersion>
+    <MicrosoftExtensionsProcessSourcesPackageVersion>2.1.0-preview2-30559</MicrosoftExtensionsProcessSourcesPackageVersion>
     <MicrosoftNETCoreApp20PackageVersion>2.0.0</MicrosoftNETCoreApp20PackageVersion>
-    <MicrosoftNETCoreApp21PackageVersion>2.1.0-preview3-26331-01</MicrosoftNETCoreApp21PackageVersion>
+    <MicrosoftNETCoreApp21PackageVersion>2.1.0-preview2-26403-06</MicrosoftNETCoreApp21PackageVersion>
     <MicrosoftNETTestSdkPackageVersion>15.6.1</MicrosoftNETTestSdkPackageVersion>
-    <SystemDataSqlClientPackageVersion>4.5.0-preview3-26331-02</SystemDataSqlClientPackageVersion>
-    <SystemSecurityCryptographyCngPackageVersion>4.5.0-preview3-26331-02</SystemSecurityCryptographyCngPackageVersion>
+    <SystemDataSqlClientPackageVersion>4.5.0-preview2-26403-05</SystemDataSqlClientPackageVersion>
+    <SystemSecurityCryptographyCngPackageVersion>4.5.0-preview2-26403-05</SystemSecurityCryptographyCngPackageVersion>
     <VisualStudio_NewtonsoftJsonPackageVersion>9.0.1</VisualStudio_NewtonsoftJsonPackageVersion>
     <XunitPackageVersion>2.3.1</XunitPackageVersion>
     <XunitRunnerVisualStudioPackageVersion>2.4.0-beta.1.build3945</XunitRunnerVisualStudioPackageVersion>

--- a/test/dotnet-watch.FunctionalTests/TestProjects/AppWithDeps/AppWithDeps.csproj
+++ b/test/dotnet-watch.FunctionalTests/TestProjects/AppWithDeps/AppWithDeps.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>exe</OutputType>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/dotnet-watch.FunctionalTests/TestProjects/Dependency/Dependency.csproj
+++ b/test/dotnet-watch.FunctionalTests/TestProjects/Dependency/Dependency.csproj
@@ -1,7 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.5</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
 </Project>

--- a/test/dotnet-watch.FunctionalTests/TestProjects/GlobbingApp/GlobbingApp.csproj
+++ b/test/dotnet-watch.FunctionalTests/TestProjects/GlobbingApp/GlobbingApp.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>exe</OutputType>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/dotnet-watch.FunctionalTests/TestProjects/KitchenSink/KitchenSink.csproj
+++ b/test/dotnet-watch.FunctionalTests/TestProjects/KitchenSink/KitchenSink.csproj
@@ -10,6 +10,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />

--- a/test/dotnet-watch.FunctionalTests/TestProjects/NoDepsApp/NoDepsApp.csproj
+++ b/test/dotnet-watch.FunctionalTests/TestProjects/NoDepsApp/NoDepsApp.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>exe</OutputType>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
 </Project>

--- a/test/dotnet-watch.FunctionalTests/dotnet-watch.FunctionalTests.csproj
+++ b/test/dotnet-watch.FunctionalTests/dotnet-watch.FunctionalTests.csproj
@@ -21,31 +21,16 @@
     <PackageReference Include="Microsoft.Extensions.CommandLineUtils.Sources" PrivateAssets="All" Version="$(MicrosoftExtensionsCommandLineUtilsSourcesPackageVersion)" />
   </ItemGroup>
 
-  <Target Name="GenerateRestoreSourcesFile" BeforeTargets="Compile">
-    <PropertyGroup>
-      <RestoreSourcesFile>$(MSBuildThisFileDirectory)/TestProjects/NuGet.config</RestoreSourcesFile>
-    </PropertyGroup>
-
-    <CreateItem Include="$(RestoreSources)">
-      <Output TaskParameter="Include" ItemName="RestoreSourcesItems"/>
-    </CreateItem>
-
-    <ItemGroup>
-      <NuGetConfigLines Include="&lt;?xml version=&quot;1.0&quot; encoding=&quot;utf-8&quot;?&gt;" />
-      <NuGetConfigLines Include="&lt;configuration&gt;" />
-      <NuGetConfigLines Include="&lt;packageSources&gt;" />
-      <NuGetConfigLines Include="&lt;clear/&gt;" />
-      <NuGetConfigLines Include="&lt;add key=&quot;%(RestoreSourcesItems.Identity)&quot; value=&quot;%(RestoreSourcesItems.Identity)&quot; /&gt;" />
-      <NuGetConfigLines Include="&lt;/packageSources&gt;" />
-      <NuGetConfigLines Include="&lt;/configuration&gt;" />
-    </ItemGroup>
-
-    <WriteLinesToFile
-      File="$(RestoreSourcesFile)"
-      Lines="@(NuGetConfigLines)"
-      Overwrite="true"
-      Encoding="UTF-8" />
-  </Target>
+  <ItemGroup>
+    <AssemblyAttribute Include="System.Reflection.AssemblyMetadataAttribute">
+      <_Parameter1>TestSettings:RestoreSources</_Parameter1>
+      <_Parameter2>$(RestoreSources)</_Parameter2>
+    </AssemblyAttribute>
+     <AssemblyAttribute Include="System.Reflection.AssemblyMetadataAttribute">
+      <_Parameter1>TestSettings:RuntimeFrameworkVersion</_Parameter1>
+      <_Parameter2>$(RuntimeFrameworkVersion)</_Parameter2>
+    </AssemblyAttribute>
+  </ItemGroup>
 
   <Target Name="CleanTestProjects" BeforeTargets="CoreCompile">
     <RemoveDir Directories="$(TargetDir)TestProjects" Condition="Exists('$(TargetDir)TestProjects')" />

--- a/testWorkDir/Directory.Build.props
+++ b/testWorkDir/Directory.Build.props
@@ -1,3 +1,0 @@
-<Project>
-<!-- Deliberately empty to prevent test apps from importing source props and targets. -->
-</Project>

--- a/testWorkDir/Directory.Build.targets
+++ b/testWorkDir/Directory.Build.targets
@@ -1,3 +1,0 @@
-<Project>
-<!-- Deliberately empty to prevent test apps from importing source props and targets. -->
-</Project>


### PR DESCRIPTION
When MicrosoftNETCoreApp21PackageVersion is overridden during a prodcon build, all dotnet-watch functional tests fail because they cannot find the right feeds to restore the package from, so they rollforward to the latest Microsoft.NETCore.App on myget. This fails because a matching runtime for that new package is not available.

Changes:
 - capture all restore feeds used during build and generate restore settings correctly (current NuGet.config generation puts the file in the wrong place)
 - capture the Microsoft.NETCore.App package version used during build and generate test settings to ensure test projects restore the same version

@Eilon @muratg @DamianEdwards - ASK
This is a test-only change, no product changes, and should fix all failing tests in release/2.1 in ProdCon builds, such as http://aspnetci/viewLog.html?buildId=440648&tab=buildResultsDiv&buildTypeId=Releases_21Public_Win2012

FYI @ryanbrandenburg 