### PR TITLE
[dotnet-watch] Don't show false error messages

### DIFF
--- a/src/dotnet-watch/DotNetWatcher.cs
+++ b/src/dotnet-watch/DotNetWatcher.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -69,13 +69,13 @@ namespace Microsoft.DotNet.Watcher
 
                     await Task.WhenAll(processTask, fileSetTask);
 
-                    if (processTask.Result == 0)
+                    if (processTask.Result != 0 && finishedTask == processTask)
                     {
-                        _reporter.Output("Exited");
+                        _reporter.Error($"Exited with error code {processTask.Result}");
                     }
                     else
                     {
-                        _reporter.Error($"Exited with error code {processTask.Result}");
+                        _reporter.Output("Exited");
                     }
 
                     if (finishedTask == cancelledTaskSource.Task || cancellationToken.IsCancellationRequested)

--- a/test/dotnet-watch.FunctionalTests/Scenario/WatchableApp.cs
+++ b/test/dotnet-watch.FunctionalTests/Scenario/WatchableApp.cs
@@ -47,7 +47,7 @@ namespace Microsoft.DotNet.Watcher.Tools.FunctionalTests
         public async Task HasExited()
         {
             await Process.GetOutputLineAsync(ExitingMessage, DefaultMessageTimeOut);
-            await Process.GetOutputLineAsync(WatchExitedMessage, DefaultMessageTimeOut);
+            await Process.GetOutputLineStartsWithAsync(WatchExitedMessage, DefaultMessageTimeOut);
         }
 
         public async Task IsWaitingForFileChange()


### PR DESCRIPTION
Don't show error when inner process exited because we killed it due to a file changing, or when the users requests cancellation via ctrl+c

*Before*
<img src="https://user-images.githubusercontent.com/2696087/39645357-ed39c0ca-4f8c-11e8-9671-44c636b885ff.png" width="400" />

*With this change*
<img src="https://user-images.githubusercontent.com/2696087/39645374-f6790a9c-4f8c-11e8-97c5-94014f208ab7.png" width="400" />

cc @glennc 
