### PR TITLE
Dispatch cancellation on CTRL+C to avoid deadlocks in killing the process tree

### DIFF
--- a/shared/CliContext.cs
+++ b/shared/CliContext.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -8,13 +8,12 @@ namespace Microsoft.Extensions.Tools.Internal
     public static class CliContext
     {
         /// <summary>
-        /// dotnet --verbose subcommand
+        /// dotnet -d|--diagnostics subcommand
         /// </summary>
         /// <returns></returns>
         public static bool IsGlobalVerbose()
         {
-            bool globalVerbose;
-            bool.TryParse(Environment.GetEnvironmentVariable("DOTNET_CLI_CONTEXT_VERBOSE"), out globalVerbose);
+            bool.TryParse(Environment.GetEnvironmentVariable("DOTNET_CLI_CONTEXT_VERBOSE"), out bool globalVerbose);
             return globalVerbose;
         }
     }

--- a/src/dotnet-watch/DotNetWatcher.cs
+++ b/src/dotnet-watch/DotNetWatcher.cs
@@ -69,8 +69,10 @@ namespace Microsoft.DotNet.Watcher
 
                     await Task.WhenAll(processTask, fileSetTask);
 
-                    if (processTask.Result != 0 && finishedTask == processTask)
+                    if (processTask.Result != 0 && finishedTask == processTask && !cancellationToken.IsCancellationRequested)
                     {
+                        // Only show this error message if the process exited non-zero due to a normal process exit.
+                        // Don't show this if dotnet-watch killed the inner process due to file change or CTRL+C by the user
                         _reporter.Error($"Exited with error code {processTask.Result}");
                     }
                     else

--- a/src/dotnet-watch/Internal/ProcessRunner.cs
+++ b/src/dotnet-watch/Internal/ProcessRunner.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -33,7 +33,7 @@ namespace Microsoft.DotNet.Watcher.Internal
             var stopwatch = new Stopwatch();
 
             using (var process = CreateProcess(processSpec))
-            using (var processState = new ProcessState(process))
+            using (var processState = new ProcessState(process, _reporter))
             {
                 cancellationToken.Register(() => processState.TryKill());
 
@@ -97,27 +97,36 @@ namespace Microsoft.DotNet.Watcher.Internal
 
         private class ProcessState : IDisposable
         {
+            private readonly IReporter _reporter;
             private readonly Process _process;
             private readonly TaskCompletionSource<object> _tcs = new TaskCompletionSource<object>();
             private volatile bool _disposed;
 
-            public ProcessState(Process process)
+            public ProcessState(Process process, IReporter reporter)
             {
+                _reporter = reporter;
                 _process = process;
                 _process.Exited += OnExited;
                 Task = _tcs.Task.ContinueWith(_ =>
                 {
-                    // We need to use two WaitForExit calls to ensure that all of the output/events are processed. Previously
-                    // this code used Process.Exited, which could result in us missing some output due to the ordering of
-                    // events.
-                    //
-                    // See the remarks here: https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics.process.waitforexit#System_Diagnostics_Process_WaitForExit_System_Int32_
-                    if (!process.WaitForExit(Int32.MaxValue))
+                    try
                     {
-                        throw new TimeoutException();
-                    }
+                        // We need to use two WaitForExit calls to ensure that all of the output/events are processed. Previously
+                        // this code used Process.Exited, which could result in us missing some output due to the ordering of
+                        // events.
+                        //
+                        // See the remarks here: https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics.process.waitforexit#System_Diagnostics_Process_WaitForExit_System_Int32_
+                        if (!_process.WaitForExit(Int32.MaxValue))
+                        {
+                            throw new TimeoutException();
+                        }
 
-                    process.WaitForExit();
+                        _process.WaitForExit();
+                    }
+                    catch (InvalidOperationException)
+                    {
+                        // suppress if this throws if no process is associated with this object anymore.
+                    }
                 });
             }
 
@@ -125,15 +134,26 @@ namespace Microsoft.DotNet.Watcher.Internal
 
             public void TryKill()
             {
+                if (_disposed)
+                {
+                    return;
+                }
+
                 try
                 {
                     if (!_process.HasExited)
                     {
+                        _reporter.Verbose($"Killing process {_process.Id}");
                         _process.KillTree();
                     }
                 }
-                catch
-                { }
+                catch (Exception ex)
+                {
+                    _reporter.Verbose($"Error while killing process '{_process.StartInfo.FileName} {_process.StartInfo.Arguments}': {ex.Message}");
+#if DEBUG
+                    _reporter.Verbose(ex.ToString());
+#endif
+                }
             }
 
             private void OnExited(object sender, EventArgs args)
@@ -143,8 +163,8 @@ namespace Microsoft.DotNet.Watcher.Internal
             {
                 if (!_disposed)
                 {
-                    _disposed = true;
                     TryKill();
+                    _disposed = true;
                     _process.Exited -= OnExited;
                     _process.Dispose();
                 }

--- a/src/dotnet-watch/Program.cs
+++ b/src/dotnet-watch/Program.cs
@@ -121,7 +121,8 @@ namespace Microsoft.DotNet.Watcher
                 _reporter.Output("Shutdown requested. Press Ctrl+C again to force exit.");
             }
 
-            _cts.Cancel();
+            // Invoke the cancellation on the default thread pool to workaround https://github.com/dotnet/corefx/issues/29699
+            ThreadPool.QueueUserWorkItem(_ => _cts.Cancel());
         }
 
         private async Task<int> MainInternalAsync(

--- a/test/dotnet-watch.FunctionalTests/GlobbingAppTests.cs
+++ b/test/dotnet-watch.FunctionalTests/GlobbingAppTests.cs
@@ -102,6 +102,7 @@ namespace Microsoft.DotNet.Watcher.Tools.FunctionalTests
             await _app.PrepareAsync();
             _app.Start(new [] { "--list" });
             var lines = await _app.Process.GetAllOutputLines();
+            var files = lines.Where(l => !l.StartsWith("watch :"));
 
             AssertEx.EqualFileList(
                 _app.Scenario.WorkFolder,
@@ -111,7 +112,7 @@ namespace Microsoft.DotNet.Watcher.Tools.FunctionalTests
                     "GlobbingApp/include/Foo.cs",
                     "GlobbingApp/GlobbingApp.csproj",
                 },
-                lines);
+                files);
         }
 
         public void Dispose()

--- a/test/dotnet-watch.FunctionalTests/Scenario/ProjectToolScenario.cs
+++ b/test/dotnet-watch.FunctionalTests/Scenario/ProjectToolScenario.cs
@@ -1,8 +1,7 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
@@ -12,7 +11,6 @@ using System.Threading.Tasks;
 using System.Xml.Linq;
 using Microsoft.Extensions.CommandLineUtils;
 using Microsoft.Extensions.Internal;
-using Microsoft.Extensions.Tools.Internal;
 using Xunit.Abstractions;
 
 namespace Microsoft.DotNet.Watcher.Tools.FunctionalTests

--- a/test/dotnet-watch.Tests/ProgramTests.cs
+++ b/test/dotnet-watch.Tests/ProgramTests.cs
@@ -28,23 +28,25 @@ namespace Microsoft.DotNet.Watcher.Tools.Tests
         {
             _tempDir
                 .WithCSharpProject("testproj")
-                .WithTargetFrameworks("netcoreapp1.0")
+                .WithTargetFrameworks("netcoreapp2.2")
                 .Dir()
                 .WithFile("Program.cs")
                 .Create();
 
-            var stdout = new StringBuilder();
-            _console.Out = new StringWriter(stdout);
-            var program = new Program(_console, _tempDir.Root)
-                .RunAsync(new[] { "run" });
+            var output = new StringBuilder();
+            _console.Error = _console.Out = new StringWriter(output);
+            using (var app = new Program(_console, _tempDir.Root))
+            {
+                var run = app.RunAsync(new[] { "run" });
 
-            await _console.CancelKeyPressSubscribed.TimeoutAfter(TimeSpan.FromSeconds(30));
-            _console.ConsoleCancelKey();
+                await _console.CancelKeyPressSubscribed.TimeoutAfter(TimeSpan.FromSeconds(30));
+                _console.ConsoleCancelKey();
 
-            var exitCode = await program.TimeoutAfter(TimeSpan.FromSeconds(30));
+                var exitCode = await run.TimeoutAfter(TimeSpan.FromSeconds(30));
 
-            Assert.Contains("Shutdown requested. Press Ctrl+C again to force exit.", stdout.ToString());
-            Assert.Equal(0, exitCode);
+                Assert.Contains("Shutdown requested. Press Ctrl+C again to force exit.", output.ToString());
+                Assert.Equal(0, exitCode);
+            }
         }
 
         public void Dispose()


### PR DESCRIPTION
Resolves https://github.com/aspnet/DotNetTools/issues/410.

This changes from calling CancellationTokenSource.Cancel inline with CTRL+C to dispatching to workaround https://github.com/dotnet/corefx/issues/29699 on macOS/Linux.