### PR TITLE
Add support for DOTNET_WATCH_ITERATION

### DIFF
--- a/build/repo.props
+++ b/build/repo.props
@@ -2,9 +2,6 @@
   <Import Project="dependencies.props" />
 
   <ItemGroup>
-    <DotNetCoreRuntime Include="2.0.0" />
-    <DotNetCoreRuntime Include="$(MicrosoftNETCoreApp20PackageVersion)" />
-    <DotNetCoreRuntime Include="$(MicrosoftNETCoreApp21PackageVersion)" />
     <DotNetCoreRuntime Include="$(MicrosoftNETCoreApp22PackageVersion)" />
   </ItemGroup>
 

--- a/src/dotnet-watch/CommandLineOptions.cs
+++ b/src/dotnet-watch/CommandLineOptions.cs
@@ -53,6 +53,10 @@ Environment variables:
   DOTNET_WATCH
   dotnet-watch sets this variable to '1' on all child processes launched.
 
+  DOTNET_WATCH_ITERATION
+  dotnet-watch sets this variable to '0' and increments by one each time
+  the inner command is restarted.
+
 Remarks:
   The special option '--' is used to delimit the end of the options and
   the beginning of arguments that will be passed to the child dotnet process.

--- a/src/dotnet-watch/DotNetWatcher.cs
+++ b/src/dotnet-watch/DotNetWatcher.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Globalization;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.DotNet.Watcher.Internal;
@@ -32,8 +33,13 @@ namespace Microsoft.DotNet.Watcher
             cancellationToken.Register(state => ((TaskCompletionSource<object>) state).TrySetResult(null),
                 cancelledTaskSource);
 
+            var iteration = 0;
+
             while (true)
             {
+                processSpec.EnvironmentVariables["DOTNET_WATCH_ITERATION"] = iteration.ToString(CultureInfo.InvariantCulture);
+                iteration++;
+
                 var fileSet = await fileSetFactory.CreateAsync(cancellationToken);
 
                 if (fileSet == null)

--- a/test/dotnet-watch.FunctionalTests/DotNetWatcherTests.cs
+++ b/test/dotnet-watch.FunctionalTests/DotNetWatcherTests.cs
@@ -3,6 +3,8 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
+using System.Globalization;
 using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
@@ -28,6 +30,23 @@ namespace Microsoft.DotNet.Watcher.Tools.FunctionalTests
             var message = await _app.Process.GetOutputLineStartsWithAsync(messagePrefix, TimeSpan.FromMinutes(2));
             var envValue = message.Substring(messagePrefix.Length);
             Assert.Equal("1", envValue);
+        }
+
+        [Fact]
+        public async Task RunsWithIterationEnvVariable()
+        {
+            await _app.StartWatcherAsync();
+            var source = Path.Combine(_app.SourceDirectory, "Program.cs");
+            const string messagePrefix = "DOTNET_WATCH_ITERATION = ";
+            for (var i = 0; i < 4; i++)
+            {
+                var message = await _app.Process.GetOutputLineStartsWithAsync(messagePrefix, TimeSpan.FromMinutes(2));
+                var count = int.Parse(message.Substring(messagePrefix.Length), CultureInfo.InvariantCulture);
+                Assert.Equal(i, count);
+
+                File.SetLastWriteTime(source, DateTime.Now);
+                await _app.HasRestarted();
+            }
         }
 
         public void Dispose()

--- a/test/dotnet-watch.FunctionalTests/TestProjects/KitchenSink/Program.cs
+++ b/test/dotnet-watch.FunctionalTests/TestProjects/KitchenSink/Program.cs
@@ -13,6 +13,7 @@ namespace KitchenSink
             Console.WriteLine("Started");
             Console.WriteLine("PID = " + Process.GetCurrentProcess().Id);
             Console.WriteLine("DOTNET_WATCH = " + Environment.GetEnvironmentVariable("DOTNET_WATCH"));
+            Console.WriteLine("DOTNET_WATCH_ITERATION = " + Environment.GetEnvironmentVariable("DOTNET_WATCH_ITERATION"));
         }
     }
 }


### PR DESCRIPTION
This environment variable can be used to determine how many types the inner command has been re-launched

Resolves #387 