### PR TITLE
Remove workaround for CTRL+C deadlocks

### DIFF
--- a/src/dotnet-watch/Program.cs
+++ b/src/dotnet-watch/Program.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -121,8 +121,7 @@ namespace Microsoft.DotNet.Watcher
                 _reporter.Output("Shutdown requested. Press Ctrl+C again to force exit.");
             }
 
-            // Invoke the cancellation on the default thread pool to workaround https://github.com/dotnet/corefx/issues/29699
-            ThreadPool.QueueUserWorkItem(_ => _cts.Cancel());
+            _cts.Cancel();
         }
 
         private async Task<int> MainInternalAsync(

--- a/test/dotnet-watch.FunctionalTests/DotNetWatcherTests.cs
+++ b/test/dotnet-watch.FunctionalTests/DotNetWatcherTests.cs
@@ -37,6 +37,7 @@ namespace Microsoft.DotNet.Watcher.Tools.FunctionalTests
         {
             await _app.StartWatcherAsync();
             var source = Path.Combine(_app.SourceDirectory, "Program.cs");
+            var contents = File.ReadAllText(source);
             const string messagePrefix = "DOTNET_WATCH_ITERATION = ";
             for (var i = 1; i <= 4; i++)
             {
@@ -44,7 +45,8 @@ namespace Microsoft.DotNet.Watcher.Tools.FunctionalTests
                 var count = int.Parse(message.Substring(messagePrefix.Length), CultureInfo.InvariantCulture);
                 Assert.Equal(i, count);
 
-                File.SetLastWriteTime(source, DateTime.Now);
+                File.Delete(source);
+                File.WriteAllText(source, contents);
                 await _app.HasRestarted();
             }
         }

--- a/test/dotnet-watch.FunctionalTests/NoDepsAppTests.cs
+++ b/test/dotnet-watch.FunctionalTests/NoDepsAppTests.cs
@@ -5,8 +5,6 @@ using System;
 using System.Diagnostics;
 using System.IO;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Testing;
-using Microsoft.AspNetCore.Testing.xunit;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -23,28 +21,6 @@ namespace Microsoft.DotNet.Watcher.Tools.FunctionalTests
         {
             _app = new WatchableApp("NoDepsApp", logger);
             _output = logger;
-        }
-
-        [ConditionalFact]
-        [OSSkipCondition(OperatingSystems.Windows, SkipReason = "Testing SIGINT is specific to macOS/Linux")]
-        public async Task KillsProcessOnSigInt()
-        {
-            void SendSigInt(int pid)
-            {
-                _output.WriteLine($"kill -SIGINT {pid}");
-                Process.Start("kill", $"-SIGINT {pid}");
-            }
-
-            await _app.StartWatcherAsync(new[] { "--no-exit" });
-
-            var childPid = await _app.GetProcessId();
-
-            SendSigInt(_app.Process.Id);
-            SendSigInt(childPid);
-
-            await _app.Process.Exited.TimeoutAfter(TimeSpan.FromSeconds(30));
-
-            Assert.DoesNotContain(_app.Process.Output, l => l.StartsWith("Exited with error code"));
         }
 
         [Fact]


### PR DESCRIPTION
The issue causing deadlocks was fixed in .NET Core 2.1.1 by @tmds, so we don't need the workaround.

Also, removing the SIGINT tests because we can't guarantee our tests run in an environment where SIGINT is honored.

Resolves #444