### PR TITLE
Attempt to fix race conditions in RunsWithIterationEnvVariable

### DIFF
--- a/test/dotnet-watch.FunctionalTests/NoDepsAppTests.cs
+++ b/test/dotnet-watch.FunctionalTests/NoDepsAppTests.cs
@@ -53,10 +53,19 @@ namespace Microsoft.DotNet.Watcher.Tools.FunctionalTests
             await _app.IsWaitingForFileChange();
 
             var fileToChange = Path.Combine(_app.SourceDirectory, "Program.cs");
-            var programCs = File.ReadAllText(fileToChange);
-            File.WriteAllText(fileToChange, programCs);
 
-            await _app.HasRestarted();
+            try
+            {
+                File.SetLastWriteTime(fileToChange, DateTime.Now);
+                await _app.HasRestarted();
+            }
+            catch
+            {
+                // retry
+                File.SetLastWriteTime(fileToChange, DateTime.Now);
+                await _app.HasRestarted();
+            }
+
             var pid2 = await _app.GetProcessId();
             Assert.NotEqual(pid, pid2);
             await _app.HasExited(); // process should exit after run


### PR DESCRIPTION
* Ensure the test app is actually watching for file changes before attempting to trigger a restart.
* Add retry if the first attempt times out

Resolves https://github.com/aspnet/DotNetTools/issues/467