### PR TITLE
Resolve flaky tests

### DIFF
--- a/test/dotnet-watch.FunctionalTests/AwaitableProcess.cs
+++ b/test/dotnet-watch.FunctionalTests/AwaitableProcess.cs
@@ -4,13 +4,12 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Threading.Tasks.Dataflow;
-using Microsoft.AspNetCore.Testing;
 using Microsoft.Extensions.Internal;
 using Microsoft.Extensions.CommandLineUtils;
 using Xunit.Abstractions;
-using System.Threading;
 
 namespace Microsoft.DotNet.Watcher.Tools.FunctionalTests
 {

--- a/test/dotnet-watch.FunctionalTests/AwaitableProcess.cs
+++ b/test/dotnet-watch.FunctionalTests/AwaitableProcess.cs
@@ -95,14 +95,10 @@ namespace Microsoft.DotNet.Watcher.Tools.FunctionalTests
 
         private async Task<string> GetOutputLineAsync(string predicateName, Predicate<string> predicate, CancellationToken cancellationToken)
         {
-            cancellationToken.ThrowIfCancellationRequested();
-
             while (!_source.Completion.IsCompleted)
             {
                 while (await _source.OutputAvailableAsync(cancellationToken))
                 {
-                    cancellationToken.ThrowIfCancellationRequested();
-
                     var next = await _source.ReceiveAsync(cancellationToken);
                     _lines.Add(next);
                     var match = predicate(next);
@@ -119,15 +115,11 @@ namespace Microsoft.DotNet.Watcher.Tools.FunctionalTests
 
         public async Task<IList<string>> GetAllOutputLinesAsync(CancellationToken cancellationToken)
         {
-            cancellationToken.ThrowIfCancellationRequested();
-
             var lines = new List<string>();
             while (!_source.Completion.IsCompleted)
             {
                 while (await _source.OutputAvailableAsync(cancellationToken))
                 {
-                    cancellationToken.ThrowIfCancellationRequested();
-
                     var next = await _source.ReceiveAsync(cancellationToken);
                     _logger.WriteLine($"{DateTime.Now}: recv: '{next}'");
                     lines.Add(next);

--- a/test/dotnet-watch.FunctionalTests/DotNetWatcherTests.cs
+++ b/test/dotnet-watch.FunctionalTests/DotNetWatcherTests.cs
@@ -13,10 +13,12 @@ namespace Microsoft.DotNet.Watcher.Tools.FunctionalTests
 {
     public class DotNetWatcherTests : IDisposable
     {
+        private readonly ITestOutputHelper _logger;
         private readonly KitchenSinkApp _app;
 
         public DotNetWatcherTests(ITestOutputHelper logger)
         {
+            _logger = logger;
             _app = new KitchenSinkApp(logger);
         }
 
@@ -52,8 +54,10 @@ namespace Microsoft.DotNet.Watcher.Tools.FunctionalTests
                     File.SetLastWriteTime(source, DateTime.Now);
                     await _app.HasRestarted();
                 }
-                catch
+                catch (Exception ex)
                 {
+                    _logger.WriteLine("Retrying. First attempt to restart app failed: " + ex.Message);
+
                     // retry
                     File.SetLastWriteTime(source, DateTime.Now);
                     await _app.HasRestarted();

--- a/test/dotnet-watch.FunctionalTests/GlobbingAppTests.cs
+++ b/test/dotnet-watch.FunctionalTests/GlobbingAppTests.cs
@@ -4,6 +4,7 @@
 using System;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.DotNet.Watcher.Tools.Tests;
 using Xunit;
@@ -101,7 +102,9 @@ namespace Microsoft.DotNet.Watcher.Tools.FunctionalTests
         {
             await _app.PrepareAsync();
             _app.Start(new [] { "--list" });
-            var lines = await _app.Process.GetAllOutputLines();
+            var cts = new CancellationTokenSource();
+            cts.CancelAfter(TimeSpan.FromSeconds(30));
+            var lines = await _app.Process.GetAllOutputLinesAsync(cts.Token);
             var files = lines.Where(l => !l.StartsWith("watch :"));
 
             AssertEx.EqualFileList(

--- a/test/dotnet-watch.FunctionalTests/NoDepsAppTests.cs
+++ b/test/dotnet-watch.FunctionalTests/NoDepsAppTests.cs
@@ -39,9 +39,6 @@ namespace Microsoft.DotNet.Watcher.Tools.FunctionalTests
 
             var pid2 = await _app.GetProcessId();
             Assert.NotEqual(pid, pid2);
-
-            // first app should have shut down
-            Assert.Throws<ArgumentException>(() => Process.GetProcessById(pid));
         }
 
         [Fact]

--- a/test/dotnet-watch.FunctionalTests/Scenario/WatchableApp.cs
+++ b/test/dotnet-watch.FunctionalTests/Scenario/WatchableApp.cs
@@ -41,8 +41,10 @@ namespace Microsoft.DotNet.Watcher.Tools.FunctionalTests
 
         public string SourceDirectory { get; }
 
-        public Task HasRestarted()
-            => Process.GetOutputLineAsync(StartedMessage, DefaultMessageTimeOut);
+        public async Task HasRestarted()
+        {
+            await Process.GetOutputLineAsync(StartedMessage, DefaultMessageTimeOut);
+        }
 
         public async Task HasExited()
         {

--- a/test/dotnet-watch.FunctionalTests/Scenario/WatchableApp.cs
+++ b/test/dotnet-watch.FunctionalTests/Scenario/WatchableApp.cs
@@ -41,10 +41,8 @@ namespace Microsoft.DotNet.Watcher.Tools.FunctionalTests
 
         public string SourceDirectory { get; }
 
-        public async Task HasRestarted()
-        {
-            await Process.GetOutputLineAsync(StartedMessage, DefaultMessageTimeOut);
-        }
+        public Task HasRestarted()
+            => Process.GetOutputLineAsync(StartedMessage, DefaultMessageTimeOut);
 
         public async Task HasExited()
         {


### PR DESCRIPTION
Resolve threeflaky tests.

1. https://github.com/aspnet/Coherence-Signed/issues/1014 - prevent an ObjectDisposedException in dotnet-watch on slower machines
1. https://github.com/aspnet/DotNetTools/issues/472 - fix flakiness caused by PID reuse
1. https://github.com/aspnet/DotNetTools/issues/472 - fix flakiness in tests that await the restart of dotnet-watch. The `.TimeoutAfter` method doesn't cancel the long-running task. This left 2 readers running on dotnet-watch output which caused indeterminate test outcome.