### PR TITLE
Push back the RTM release of dotnet-httprepl

### DIFF
--- a/NuGetPackageVerifier.json
+++ b/NuGetPackageVerifier.json
@@ -24,20 +24,6 @@
           "DotnetTool"
         ]
       },
-      "dotnet-httprepl": {
-        "packageTypes": [
-          "DotnetTool"
-        ],
-        "Exclusions": {
-          "ASSEMBLY_DESCRIPTION": {
-            "tools/netcoreapp2.1/any/System.Net.Http.Formatting.dll": "Referenced assembly, not built as part of this process"
-          },
-          "VERSION_INFORMATIONALVERSION": {
-            "tools/netcoreapp2.1/any/Newtonsoft.Json.dll": "Referenced assembly, not built as part of this process",
-            "tools/netcoreapp2.1/any/Newtonsoft.Json.Bson.dll": "Referenced assembly, not built as part of this process"
-          }
-        }
-      },
       "Microsoft.AspNetCore.DeveloperCertificates.XPlat": {
         "Exclusions": {
           "DOC_MISSING": {

--- a/src/Microsoft.HttpRepl/Microsoft.HttpRepl.csproj
+++ b/src/Microsoft.HttpRepl/Microsoft.HttpRepl.csproj
@@ -10,6 +10,9 @@
     <PackageTags>dotnet;http;httprepl</PackageTags>
     <!-- This is a requirement for Microsoft tool packages only. -->
     <PackAsToolShimRuntimeIdentifiers>win-x64;win-x86</PackAsToolShimRuntimeIdentifiers>
+    
+    <!-- Temporarily disables producing this project as a package while we work through some RTM-blocking bugs. -->
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This package isn't quite ship-shape yet, so we're delaying this from shipping with 2.2 RTM.

Setting IsPackable=false so we avoid accidentally building a 2.2.0 RTM version of this package along with the rest of the 2.2.0 RTM tools in this repo, like dotnet-watch.